### PR TITLE
Add Automated Maven Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Snapshot build and publish
+    runs-on: ubuntu-latest
+    environment: PRODUCTION
+    timeout-minutes: 120
+    env:
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+      SONATYPE_CONNECT_TIMEOUT_SECONDS: 120
+      SONATYPE_CLOSE_TIMEOUT_SECONDS: 1800
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.1.0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3.5.1
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Grant Permission to Execute Gradle
+        run: chmod +x gradlew
+
+      - name: Publish to MavenCentral
+        run: |
+          ./gradlew :plugin:winds-api:publish --no-configuration-cache

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,8 +7,10 @@ buildscript {
 
 // Lists all plugins used throughout the project without applying them.
 plugins {
+  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.dokka)
   alias(libs.plugins.spotless)
+  alias(libs.plugins.vanniktech.maven)
 }
 
 val ktlintVersion = "0.50.0"


### PR DESCRIPTION
This pull request introduces an automated Maven publishing workflow to streamline the release process for the project. The changes include the addition of the necessary configuration and actions to automatically publish artifacts to the Maven repository. This workflow ensures that the build artifacts are seamlessly deployed and accessible to consumers.

Key Changes:
- Added Maven publishing workflow to automatically publish project artifacts.
- Configured actions to handle the Maven Central publication process.
- Updated project settings and configurations for streamlined publishing.
