### PR TITLE
Bug-Fix: Added Javadoc for Developer Interface Properties and Introduced Email Field

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,7 @@ subprojects {
 data class TeogorDeveloper(
   override val id: String = "teogor",
   override val name: String = "Teodor Grigor",
+  override val email: String = "open-source@teogor.dev",
   override val url: String = "https://teogor.dev",
   override val roles: List<String> = listOf("Code Owner", "Developer", "Designer", "Maintainer"),
   override val timezone: String = "UTC+2",

--- a/plugin/winds-api/src/main/kotlin/dev/teogor/winds/api/model/Developer.kt
+++ b/plugin/winds-api/src/main/kotlin/dev/teogor/winds/api/model/Developer.kt
@@ -19,6 +19,7 @@ package dev.teogor.winds.api.model
 interface Developer {
   val id: String
   val name: String
+  val email: String
   val url: String
   val roles: List<String>
   val timezone: String
@@ -29,6 +30,7 @@ interface Developer {
 data class DeveloperImpl(
   override var id: String = "",
   override var name: String = "",
+  override var email: String = "",
   override var url: String = "",
   override var roles: List<String> = emptyList(),
   override var timezone: String = "",

--- a/plugin/winds-api/src/main/kotlin/dev/teogor/winds/api/model/Developer.kt
+++ b/plugin/winds-api/src/main/kotlin/dev/teogor/winds/api/model/Developer.kt
@@ -16,14 +16,49 @@
 
 package dev.teogor.winds.api.model
 
+/**
+ * A developer involved in the project.
+ */
 interface Developer {
+
+  /**
+   * The unique ID of this developer in the SCM.
+   */
   val id: String
+
+  /**
+   * The name of this developer.
+   */
   val name: String
+
+  /**
+   * The email of this developer.
+   */
   val email: String
+
+  /**
+   * The URL of this developer.
+   */
   val url: String
+
+  /**
+   * The roles of this developer.
+   */
   val roles: List<String>
+
+  /**
+   * The timezone of this developer.
+   */
   val timezone: String
+
+  /**
+   * The organization name of this developer.
+   */
   val organization: String
+
+  /**
+   * The organization's URL of this developer.
+   */
   val organizationUrl: String
 }
 

--- a/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
+++ b/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
@@ -63,6 +63,7 @@ inline fun Project.checkPluginApplied(crossinline block: Winds.() -> Unit) {
   }
 }
 
+// todo kotlin-dsl
 private val publishPlugins = listOf(
   "com.android.library",
   "com.gradle.plugin-publish",
@@ -135,6 +136,7 @@ fun List<Developer>.toDeveloperSpec(
     mavenPomDeveloperSpec.developer {
       id.set(developer.id)
       name.set(developer.name)
+      email.set(developer.email)
       url.set(developer.url)
       roles.set(developer.roles)
       timezone.set(developer.timezone)


### PR DESCRIPTION
This pull request enhances the `Developer` interface by adding comprehensive Javadoc comments for its properties and introduces a new field, `email`. The Javadoc improves the documentation and provides a better understanding of the purpose of each property. The newly added `email` field is an essential addition to the `Developer` interface, enabling developers to include email information for developers associated with Maven publications.

Closes #6 