### PR TITLE
Winds Plugin v1.0.0-alpha02 Release

### DIFF
--- a/.resources/bom/1.0.0-alpha02/dependencies-1.0.0-alpha02.json
+++ b/.resources/bom/1.0.0-alpha02/dependencies-1.0.0-alpha02.json
@@ -1,0 +1,192 @@
+[
+  {
+    "completeName": "Winds Demo Tst 2",
+    "name": "demo-kotlin-dsl-tst2",
+    "displayName": "Demo Tst 2",
+    "description": "Demo 2 Description set in here",
+    "groupId": "dev.teogor.winds",
+    "artifactId": "winds-demo-kotlin-dsl-tst2",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Alpha",
+      "versionQualifier": 1
+    },
+    "path": ":demo-2",
+    "dependencies": [
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "embeddedKotlin",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-stdlib-jdk8",
+        "version": "1.8.20"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "embeddedKotlin",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-reflect",
+        "version": "1.8.20"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathMain",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-scripting-compiler-embeddable",
+        "version": "1.9.10"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathMain",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-sam-with-receiver",
+        "version": "1.9.10"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathMain",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-assignment",
+        "version": "1.9.10"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathTest",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-scripting-compiler-embeddable",
+        "version": "1.9.10"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathTest",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-sam-with-receiver",
+        "version": "1.9.10"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.Dependency",
+        "implementationType": "kotlinCompilerPluginClasspathTest",
+        "group": "org.jetbrains.kotlin",
+        "artifact": "kotlin-assignment",
+        "version": "1.9.10"
+      }
+    ],
+    "canBePublished": true,
+    "names": [
+      "Winds",
+      "Demo Tst 2"
+    ]
+  },
+  {
+    "completeName": "Winds Module 1 Library 1",
+    "name": "library-1",
+    "displayName": "Library 1",
+    "description": "M#1 Library 1 Description set in here",
+    "groupId": "dev.teogor.winds",
+    "artifactId": "module-1-library-1",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Alpha",
+      "versionQualifier": 1
+    },
+    "path": ":module:library-1",
+    "dependencies": [
+      {
+        "type": "dev.teogor.winds.api.model.LocalProjectDependency",
+        "implementationType": "api",
+        "projectName": "Winds",
+        "modulePath": ":module:library-2"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.LocalProjectDependency",
+        "implementationType": "compileOnly",
+        "projectName": "Winds",
+        "modulePath": ":module:library-4"
+      },
+      {
+        "type": "dev.teogor.winds.api.model.LocalProjectDependency",
+        "implementationType": "implementation",
+        "projectName": "Winds",
+        "modulePath": ":module:library-3"
+      }
+    ],
+    "canBePublished": true,
+    "names": [
+      "Winds",
+      "Module 1",
+      "Library 1"
+    ]
+  },
+  {
+    "completeName": "Winds Module 1 Library 2",
+    "name": "library-2",
+    "displayName": "Library 2",
+    "description": "Module 1 Description set in here",
+    "groupId": "dev.teogor.winds",
+    "artifactId": "module-1-library-2",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Alpha",
+      "versionQualifier": 1
+    },
+    "path": ":module:library-2",
+    "dependencies": [
+    ],
+    "canBePublished": true,
+    "names": [
+      "Winds",
+      "Module 1",
+      "Library 2"
+    ]
+  },
+  {
+    "completeName": "Winds Module 1 Library 3",
+    "name": "library-3",
+    "displayName": "Library 3",
+    "description": "Module 1 Description set in here",
+    "groupId": "dev.teogor.winds",
+    "artifactId": "module-1-library-3",
+    "version": {
+      "major": 3,
+      "minor": 8,
+      "patch": 2,
+      "flag": "Deprecated"
+    },
+    "path": ":module:library-3",
+    "dependencies": [
+    ],
+    "canBePublished": true,
+    "names": [
+      "Winds",
+      "Module 1",
+      "Library 3"
+    ]
+  },
+  {
+    "completeName": "Winds Module 1 Library 4",
+    "name": "library-4",
+    "displayName": "Library 4",
+    "description": "Module 1 Description set in here",
+    "groupId": "dev.teogor.winds",
+    "artifactId": "module-1-library-4",
+    "version": {
+      "major": 6,
+      "minor": 2,
+      "patch": 4
+    },
+    "path": ":module:library-4",
+    "dependencies": [
+    ],
+    "canBePublished": true,
+    "names": [
+      "Winds",
+      "Module 1",
+      "Library 4"
+    ]
+  }
+]

--- a/.resources/bom/versions.json
+++ b/.resources/bom/versions.json
@@ -8,5 +8,15 @@
       "versionQualifier": 1
     },
     "date": 1699022278
+  },
+  {
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0,
+      "flag": "Alpha",
+      "versionQualifier": 2
+    },
+    "date": 1699454402
   }
 ]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To implement the Winds plugin, add the following plugin ID to your build.gradle 
 
 ```kotlin
 plugins {
-  id "dev.teogor.winds" version "1.0.0-alpha01"
+  id "dev.teogor.winds" version "1.0.0-alpha02"
 }
 ```
 
@@ -40,7 +40,7 @@ The following is an example build.gradle file that uses the Winds plugin to buil
 
 ```kotlin
 plugins {
-  id "dev.teogor.winds" version "1.0.0-alpha01"
+  id "dev.teogor.winds" version "1.0.0-alpha02"
 }
 
 winds {

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -16,7 +16,7 @@ winds {
       major = 1,
       minor = 0,
       patch = 0,
-    ).setAlphaRelease(1)
+    ).setAlphaRelease(2)
 
     defineBoM()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ winds {
 
     canBePublished = false
 
-    description = "Here goes the description"
+    description = "\uD83C\uDF43 Winds build and publish libraries and applications for multiple platforms, simple and efficient."
 
 
     groupId = "dev.teogor.winds"

--- a/docs/bom/1.0.0-alpha02/bom-version-1.0.0-alpha02.md
+++ b/docs/bom/1.0.0-alpha02/bom-version-1.0.0-alpha02.md
@@ -1,0 +1,43 @@
+# Winds BoM v1.0.0-alpha02 (Bill of Materials)
+
+The Winds BoM (Bill of Materials) enables you to manage all your Winds library versions by specifying only one version — the BoM's version.
+
+When you use the Winds BoM in your app, the BoM automatically pulls in the individual library versions mapped to the BoM's version. All the individual library versions will be compatible. When you update the BoM's version in your app, all the Winds libraries that you use in your app will update to the versions mapped to that BoM version.
+
+To learn which Winds library versions are mapped to a specific BoM version, check out the release notes for that BoM version. If you need to compare the library versions mapped to one BoM version compared to another BoM version, use the comparison widget below.
+
+Learn more about [Gradle's support for BoM platforms](https://docs.gradle.org/4.6-rc-1/userguide/managing_transitive_dependencies.html#sec:bom_import).
+
+Here's how to use the Winds BoM to declare dependencies in your module (app-level) Gradle file (usually app/build.gradle.kts). When using the BoM, you don't specify individual library versions in the dependency lines.
+
+```kt
+dependencies {
+  // Import the BoM for the Winds platform
+  implementation(platform("dev.teogor.winds:bom:1.0.0-alpha02"))
+
+  // Declare the dependencies for the desired Winds products
+  // without specifying versions. For example, declare:
+  // Winds Module 1 Library 3
+  implementation("dev.teogor.winds:module-1-library-3")
+  // Winds Demo Tst 2
+  implementation("dev.teogor.winds:winds-demo-kotlin-dsl-tst2")
+  // Winds Module 1 Library 1
+  implementation("dev.teogor.winds:module-1-library-1")
+}
+```
+
+## Latest SDK versions
+
+| Status | Service or Product | Gradle dependency | Latest version |
+| ------ | ------------------ | ----------------- | -------------- |
+| 🧪 | [demo-kotlin-dsl-tst2](/demo-2) | dev.teogor.winds:winds-demo-kotlin-dsl-tst2 | 1.0.0-alpha01 |
+| 🧪 | [library-1](/module/library-1) | dev.teogor.winds:module-1-library-1 | 1.0.0-alpha01 |
+| 🧪 | [library-2](/module/library-2) | dev.teogor.winds:module-1-library-2 | 1.0.0-alpha01 |
+| 🚧 | [library-3](/module/library-3) | dev.teogor.winds:module-1-library-3 | 3.8.2 |
+|  | [library-4](/module/library-4) | dev.teogor.winds:module-1-library-4 | 6.2.4 |
+
+### Explore Further
+
+For the latest updates, in-depth documentation, and a comprehensive overview of the Winds ecosystem, visit the official [Winds documentation](/docs/). It's your gateway to a wealth of resources and insights that will elevate your Winds development journey.
+
+Stay informed, stay current, and embrace the full potential of Winds.

--- a/docs/bom/versions.md
+++ b/docs/bom/versions.md
@@ -5,12 +5,12 @@ It enables you to effortlessly keep track of the latest versions of key componen
 
 ### Latest Version
 
-Here is how to declare dependencies using the latest version `1.0.0-alpha01`:
+Here is how to declare dependencies using the latest version `1.0.0-alpha02`:
 
 ```kt
 dependencies {
   // Import the BoM for the Winds platform using the latest version
-  implementation(platform("dev.teogor.winds:bom:1.0.0-alpha01"))
+  implementation(platform("dev.teogor.winds:bom:1.0.0-alpha02"))
 }
 ```
 
@@ -20,6 +20,7 @@ Below is a list of the latest versions of the BOM:
 
 | Version | Release Notes | Release Date |
 | ------- | ------------- | ------------ |
+| 1.0.0-alpha02 | [changelog 🔗](/docs/bom/1.0.0-alpha02/bom-version-1.0.0-alpha02.md) | 08 Nov 2023 |
 | 1.0.0-alpha01 | [changelog 🔗](/docs/bom/1.0.0-alpha01/bom-version-1.0.0-alpha01.md) | 03 Nov 2023 |
 
 The **Bill of Materials (BoM)** serves as a cornerstone for maintaining synchronization among various libraries and components in your project. By centralizing version management, it significantly reduces compatibility issues and streamlines the entire dependency management process.

--- a/docs/version-catalog.md
+++ b/docs/version-catalog.md
@@ -4,7 +4,7 @@ This catalog provides the implementation details of Winds libraries, including B
 
 ```toml
 [versions]
-winds-bom = "1.0.0-alpha01"
+winds-bom = "1.0.0-alpha02"
 
 [libraries]
 # Winds BoM

--- a/plugin/winds-api/build.gradle.kts
+++ b/plugin/winds-api/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "dev.teogor.winds"
-version = "1.0.0-alpha01"
+version = "1.0.0-alpha02"
 
 val javaVersion = JavaVersion.VERSION_1_8
 java {

--- a/plugin/winds/build.gradle.kts
+++ b/plugin/winds/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
 }
 
 group = "dev.teogor.winds"
-version = "1.0.0-alpha01"
+version = "1.0.0-alpha02"
 
 gradlePlugin {
   website.set("https://source.teogor.dev/winds")


### PR DESCRIPTION
## Winds Plugin v1.0.0-alpha02 Release

This release marks a significant milestone in the development of the Winds plugin, bringing enhanced features and improved stability to the plugin's core functionality.

### Upgrade Instructions

To upgrade to this release, simply update the Winds plugin in your project's Gradle dependencies:

```kt
plugins {
    id("dev.teogor.winds") version "1.0.0-alpha02"
}
```