### PR TITLE
Fix missing license in PoM

### DIFF
--- a/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/ErrorIds.kt
+++ b/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/ErrorIds.kt
@@ -19,4 +19,8 @@ sealed interface ErrorId {
   object BomLibraryError : ErrorId {
     override val errorId: Int = 1002
   }
+
+  object PomLicenseError : ErrorId {
+    override val errorId: Int = 1003
+  }
 }


### PR DESCRIPTION
This pull request fixes the issue of missing licenses in POM files for Gradle projects using the Winds plugin. The previous implementation did not guarantee that a license would be included in the POM, leading to situations where projects were published to Maven Central without a license.

This change ensures that a license is always included in the POM by providing a default license if the `mavenPublish.licenses` property is null. This ensures that projects using the Winds plugin are always published with a license.

Here are the specific changes made in this pull request:

1. Added a new method, `licenseError`, to the `Winds` extension. This method throws an error if a license is not provided for the project.
2. The `licenseError` method is called in the `configureBomModule` method. This ensures that the error is thrown if a license is not provided for the BoM module.
3. The `licenseError` method is also called in the `afterWindsPluginConfiguration` hook. This ensures that the error is thrown if a license is not provided for any of the subprojects.

This change ensures that all Gradle projects using the Winds plugin are published with a license. This makes the plugin more user-friendly and helps to ensure that projects are compliant with Maven Central guidelines.

Closes #21 