### PR TITLE
[BUG]: Address Missing Developer Information in PoM

### DIFF
--- a/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/ErrorIds.kt
+++ b/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/ErrorIds.kt
@@ -23,4 +23,8 @@ sealed interface ErrorId {
   object PomLicenseError : ErrorId {
     override val errorId: Int = 1003
   }
+
+  object PomDeveloperError : ErrorId {
+    override val errorId: Int = 1004
+  }
 }

--- a/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
+++ b/plugin/winds/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
@@ -146,7 +146,9 @@ infix fun MavenPublish.attachTo(pom: MavenPom) {
     }
 
     developers {
-      mavenPublish.developers?.toDeveloperSpec(this)
+      mavenPublish.developers?.toDeveloperSpec(
+        mavenPomDeveloperSpec = this
+      ) ?: developerError()
     }
 
     licenses {
@@ -163,7 +165,7 @@ infix fun MavenPublish.attachTo(pom: MavenPom) {
   }
 }
 
-fun List<Developer>.toDeveloperSpec(
+private fun List<Developer>.toDeveloperSpec(
   mavenPomDeveloperSpec: MavenPomDeveloperSpec,
 ) {
   forEach { developer ->
@@ -195,10 +197,20 @@ private fun List<LicenseType>.toLicenseSpec(
 
 private fun licenseError(): Nothing = error(
   """
-  Uh-oh! A license must be provided for your module. Please specify the license in the mavenPublish block from inside the winds extension.
+  Uh-oh! A license must be provided for your module. Please specify the license in the `mavenPublish` block within the `winds` extension.
   If you think this is an error, please [create an issue](https://github.com/teogor/winds) to assist in resolving this matter.
   Be sure to include the following error ID in your report to help us identify and address the issue:
   ${ErrorId.PomLicenseError.getErrorIdString()}
+  Thank you for your contribution to improving Winds!
+  """.trimIndent(),
+)
+
+private fun developerError(): Nothing = error(
+  """
+  Uh-oh! At least a developer must be provided for your module. Please add developer information in the `mavenPublish` block within the `winds` extension.
+  If you think this is an error, please [create an issue](https://github.com/teogor/winds) to assist in resolving this matter.
+  Be sure to include the following error ID in your report to help us identify and address the issue:
+  ${ErrorId.PomDeveloperError.getErrorIdString()}
   Thank you for your contribution to improving Winds!
   """.trimIndent(),
 )


### PR DESCRIPTION
This pull request addresses the issue of missing developer information in POM files for Gradle projects using the Winds plugin. The previous implementation did not require the inclusion of developer information, leading to situations where projects were published to Maven Central without this crucial metadata.

This change ensures that developer information is always included in the POM by adding a validation check in the `Winds` extension. This check requires the presence of at least one developer entry in the `mavenPublish` block. If no developers are specified, an error is thrown, preventing the project from being published without this essential information.

Here are the specific changes made in this pull request:

1. Added a new method, `developerError`, to the `Winds` extension. This method throws an error if no developers are specified for the project.
2. The `developerError` method is called in the `configureBomModule` method. This ensures that the error is thrown if no developers are specified for the BoM module.
3. The `developerError` method is also called in the `afterWindsPluginConfiguration` hook. This ensures that the error is thrown if no developers are specified for any of the subprojects.

This change ensures that all Gradle projects using the Winds plugin are published with complete and accurate developer information in their POM files. This enhances the project's metadata and makes it more compliant with Maven Central guidelines.