### PR TITLE
Centralize Group and Version for Improved Subproject Management

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
   alias(libs.plugins.vanniktech.maven) apply true
 }
 
-// todo centralize winds version
-group = "dev.teogor.winds"
-version = "1.0.0-alpha02"
-
 val javaVersion = JavaVersion.VERSION_1_8
 java {
   sourceCompatibility = javaVersion
@@ -60,7 +56,7 @@ mavenPublishing {
     coordinates(
       groupId = "dev.teogor.winds",
       artifactId = "winds-api",
-      version = "1.0.0-alpha02",
+      version = version.toString(),
     )
 
     licenses {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,12 @@ plugins {
   alias(libs.plugins.api.validator) apply true // Enable API Validator for API validation
 }
 
+// Explicitly set the group and version for all subprojects
+subprojects {
+  group = "dev.teogor.winds"
+  version = "1.0.0-alpha03"
+}
+
 val ktlintVersion = "0.50.0"
 
 val excludedProjects = listOf(

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
   alias(libs.plugins.vanniktech.maven) apply true
 }
 
-// todo centralize winds version
-group = "dev.teogor.winds"
-version = "1.0.0-alpha02"
-
 val javaVersion = JavaVersion.VERSION_1_8
 java {
   sourceCompatibility = javaVersion
@@ -47,15 +43,15 @@ mavenPublishing {
   signAllPublications()
 
   pom {
-    name.set("Winds API")
+    name.set("Winds Common")
     description.set("\uD83C\uDF43 Winds build and publish libraries and applications for multiple platforms, simple and efficient.")
-    url.set("https://github.com/teogor/winds")
+    url.set("https://source.teogor.dev/winds")
     inceptionYear.set("2023")
 
     coordinates(
       groupId = "dev.teogor.winds",
       artifactId = "winds-common",
-      version = "1.0.0-alpha02",
+      version = version.toString(),
     )
 
     licenses {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -24,10 +24,6 @@ plugins {
   alias(libs.plugins.vanniktech.maven)
 }
 
-// todo
-group = "dev.teogor.winds"
-version = "1.0.0-alpha02"
-
 repositories {
   mavenLocal()
   maven(url = "https://maven.google.com/")


### PR DESCRIPTION
## Benefits of Centralized Group and Version

* **Improved Consistency:** Ensures all subprojects share the same group and version, making it easier to identify and organize related projects.

* **Simplified Management:** Reduces the need to manually configure group and version properties for each subproject, streamlining project maintenance.

* **Enhanced Clarity:** Provides a clear and consistent indication of the project's affiliation and release stage.

## Changes Introduced

This PR modifies the `settings.gradle.kts` file to include the following code snippet:

```kotlin
subprojects {
  group = "dev.teogor.winds"
  version = "1.0.0-alpha03"
}
```

This code applies the specified group and version to all subprojects within the Gradle build.

## Impact on Subprojects

All subprojects will now share the group "dev.teogor.winds" and the version "1.0.0-alpha03". This ensures consistency and simplifies project management.
