### PR TITLE
Enrich Action Workflow with Accurate Publish Commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,4 +33,5 @@ jobs:
 
       - name: Publish to MavenCentral
         run: |
-          ./gradlew :plugin:winds-api:publish --no-configuration-cache
+          ./gradlew :api:publish --no-configuration-cache
+          ./gradlew :common:publish --no-configuration-cache

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,4 +4,9 @@
     <asm skipDebug="true" skipFrames="true" skipCode="false" expandFrames="false" />
     <groovy codeStyle="LEGACY" />
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
 </project>


### PR DESCRIPTION

## Addressing Incorrect Publish Commands

This PR addresses the previously used incorrect publish commands `./gradlew :plugin:winds-api:publish --no-configuration-cache` within the action workflow. These commands were targeting the wrong modules, potentially leading to unintended publishing actions.

## Implemented Corrections

To rectify the issue, this PR introduces the following changes:

* Replaced `./gradlew :plugin:winds-api:publish --no-configuration-cache` with the accurate command `/gradlew :api:publish --no-configuration-cache
          ./gradlew :common:publish --no-configuration-cache`

These changes ensure that the action workflow correctly publishes the `api` and `common` modules, aligning with the intended behavior.

## Improved Workflow Accuracy

By implementing these corrections, we enhance the accuracy and reliability of the action workflow, ensuring that the correct modules are published during the automated build process.

## Review and Feedback

Please review the changes introduced in this PR and provide any feedback or suggestions.
