### PR TITLE
 Introduce `ProjectPluginUtils` for Managing Project Plugins

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -74,3 +74,10 @@ public final class dev/teogor/winds/common/utils/MavenPomUtilsKt {
 	public static final fun attachMavenData (Lorg/gradle/api/publish/maven/MavenPom;Ldev/teogor/winds/api/MavenPublish;)V
 }
 
+public final class dev/teogor/winds/common/utils/ProjectPluginUtilsKt {
+	public static final fun hasAndroidLibraryPlugin (Lorg/gradle/api/Project;)Z
+	public static final fun hasKotlinDslPlugin (Lorg/gradle/api/Project;)Z
+	public static final fun hasPublishPlugin (Lorg/gradle/api/Project;)Z
+	public static final fun hasWindsPlugin (Lorg/gradle/api/Project;)Z
+}
+

--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.common.utils
+
+import org.gradle.api.Project
+
+/**
+ * A list of Gradle plugins that are considered publishing plugins.
+ * These plugins are typically used to publish libraries or other artifacts to a repository.
+ */
+private val publishPlugins = listOf(
+  "com.android.library",
+  "com.gradle.plugin-publish",
+  "org.jetbrains.kotlin.multiplatform",
+  "org.jetbrains.kotlin.jvm",
+  "org.jetbrains.kotlin.js",
+  "java",
+  "java-library",
+  "java-platform",
+  "java-gradle-plugin",
+  "version-catalog",
+)
+
+/**
+ * Checks whether the project has the Android library plugin applied.
+ *
+ * @return `true` if the project has the Android library plugin applied, `false` otherwise.
+ */
+fun Project.hasAndroidLibraryPlugin(): Boolean {
+  return plugins.hasPlugin("com.android.library")
+}
+
+/**
+ * Checks whether the project has the Kotlin DSL plugin applied.
+ *
+ * @return `true` if the project has the Kotlin DSL plugin applied, `false` otherwise.
+ */
+fun Project.hasKotlinDslPlugin(): Boolean {
+  return plugins.hasPlugin("org.gradle.kotlin.kotlin-dsl")
+}
+
+/**
+ * Checks whether the project has any of the publishing plugins applied.
+ *
+ * @return `true` if the project has any of the publishing plugins applied, `false` otherwise.
+ */
+fun Project.hasPublishPlugin(): Boolean {
+  return publishPlugins.any { plugins.hasPlugin(it) }
+}
+
+/**
+ * Checks whether the project has the Winds plugin applied.
+ *
+ * @return `true` if the project has the Winds plugin applied, `false` otherwise.
+ */
+fun Project.hasWindsPlugin(): Boolean {
+  return project.plugins.hasPlugin("dev.teogor.winds")
+}

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -170,7 +170,7 @@ public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt {
 	public static final fun getAllDependencies (Lorg/gradle/api/Project;)Ljava/util/List;
 	public static final fun hasKotlinDslPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasPublishPlugin (Lorg/gradle/api/Project;)Z
-	public static final fun isAndroidModule (Lorg/gradle/api/Project;)Z
+	public static final fun isAndroidLibrary (Lorg/gradle/api/Project;)Z
 	public static final fun isWindsApplied (Lorg/gradle/api/Project;)Z
 	public static final fun isWindsApplied (Lorg/gradle/api/Project;ZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun isWindsApplied$default (Lorg/gradle/api/Project;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/impl/MavenPublishUtils.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/impl/MavenPublishUtils.kt
@@ -21,10 +21,10 @@ import dev.teogor.winds.api.Winds
 import dev.teogor.winds.api.getValue
 import dev.teogor.winds.api.impl.MavenPublishImpl
 import dev.teogor.winds.api.model.WindsFeature
+import dev.teogor.winds.common.utils.hasAndroidLibraryPlugin
+import dev.teogor.winds.common.utils.hasKotlinDslPlugin
+import dev.teogor.winds.common.utils.hasPublishPlugin
 import dev.teogor.winds.gradle.utils.configureBomModule
-import dev.teogor.winds.gradle.utils.hasKotlinDslPlugin
-import dev.teogor.winds.gradle.utils.hasPublishPlugin
-import dev.teogor.winds.gradle.utils.isAndroidModule
 import dev.teogor.winds.gradle.utils.windsPluginConfiguration
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getValue
@@ -34,7 +34,7 @@ fun Project.configureMavenPublish() {
   val base = this
 
   // Apply publish plugins only for Android modules due to Maven plugin requirements
-  if (isAndroidModule()) {
+  if (hasAndroidLibraryPlugin()) {
     val winds: Winds by extensions
     val maven: MavenPublish by winds
     if (hasKotlinDslPlugin()) {


### PR DESCRIPTION
This pull request introduces a new utility file named `ProjectPluginUtils.kt` to provide convenient methods for checking and managing project plugins. This file contains functions for determining whether a project has specific plugins, such as the Android library plugin or the Kotlin DSL plugin. These functions can be used to streamline build scripts and make conditional logic more concise.

Key benefits of introducing `ProjectPluginUtils.kt`:

1. **Reduced Code Redundancy:** Eliminates the need to repeat plugin check code in multiple places, promoting code reusability and maintainability.

2. **Enhanced Build Script Readability:** Improves the readability of build scripts by encapsulating plugin-related logic in a dedicated file.

3. **Concise Conditional Logic:** Enables concise and expressive conditional checks based on plugin availability.

4. **Modular Plugin Management:** Facilitates modular plugin management and simplifies plugin-specific build logic.