### PR TITLE
Introduce `processWindsChildProjects` for Streamlined Child Project Processing

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -79,5 +79,6 @@ public final class dev/teogor/winds/common/utils/ProjectPluginUtilsKt {
 	public static final fun hasKotlinDslPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasPublishPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasWindsPlugin (Lorg/gradle/api/Project;)Z
+	public static final fun processWindsChildProjects (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
@@ -70,3 +70,19 @@ fun Project.hasPublishPlugin(): Boolean {
 fun Project.hasWindsPlugin(): Boolean {
   return project.plugins.hasPlugin("dev.teogor.winds")
 }
+
+/**
+ * Applies a given action to all child projects that have the Winds plugin applied.
+ *
+ * @param action The action to apply to each Wind-enabled child project.
+ */
+inline fun Project.processWindsChildProjects(
+  crossinline action: Project.() -> Unit,
+) {
+  childProjects.values
+    .toList()
+    .filter { hasWindsPlugin() }
+    .forEach {
+      it.action()
+    }
+}

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -165,6 +165,7 @@ public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt {
 	public static final fun attachTo (Ldev/teogor/winds/api/MavenPublish;Lorg/gradle/api/publish/maven/MavenPom;)V
 	public static final fun checkPluginApplied (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V
 	public static final fun collectModulesInfo (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V
+	public static final fun configureWindsPluginConfiguration (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function2;)V
 	public static final fun copyVersion (Ldev/teogor/winds/api/MavenPublish;Lkotlin/jvm/functions/Function1;)Ldev/teogor/winds/api/model/Version;
 	public static synthetic fun copyVersion$default (Ldev/teogor/winds/api/MavenPublish;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/teogor/winds/api/model/Version;
 	public static final fun getAllDependencies (Lorg/gradle/api/Project;)Ljava/util/List;
@@ -178,7 +179,12 @@ public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt {
 	public static final fun windsPluginConfiguration (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function2;)V
 }
 
-public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt$afterWindsPluginConfiguration$1$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt$configureWindsPluginConfiguration$2$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun execute (Ljava/lang/Object;)V
+}
+
+public final class dev/teogor/winds/gradle/utils/WindsExtensionsKt$inlined$sam$i$org_gradle_api_Action$0 : org/gradle/api/Action {
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public final synthetic fun execute (Ljava/lang/Object;)V
 }


### PR DESCRIPTION
This pull request introduces a new extension function named `processWindsChildProjects` to the `ProjectPluginUtils` file. This function simplifies the process of applying actions to child projects that have the Winds plugin applied. It eliminates the need for explicit filtering and iteration, making it more concise and efficient.

**Usage Example:**

```kotlin
project.processWindsChildProjects {
  // Perform an action on each Wind-enabled child project
  configureMavenPublish()
}
```

By introducing `processWindsChildProjects`, we can streamline and simplify the management of child projects within the Winds plugin ecosystem.