### PR TITLE
Fix infinite loop in MavenPublish `displayName` getter

### DIFF
--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
@@ -26,7 +26,7 @@ import org.gradle.api.publish.maven.MavenPomLicenseSpec
 
 fun attachMavenData(pom: MavenPom, mavenPublish: MavenPublish) {
   pom.apply {
-    name.set(mavenPublish.displayName)
+    name.set(mavenPublish.completeName)
     description.set(mavenPublish.description)
     inceptionYear.set(mavenPublish.inceptionYear.toString())
     url.set(mavenPublish.url)


### PR DESCRIPTION
This pull request addresses an issue where the `displayName` getter in the `MavenPublish` interface creates an infinite loop when calling the `gets` function with a nested selector referencing itself.

**Details:**

The bug occurs when this call chain happens:
    1. `displayName` getter is called.
    2. Within the getter, `gets` is called with a selector that retrieves data necessary for display name construction.
    3. If the selector indirectly or directly references `displayName`, an infinite loop is triggered.

**Potential Impact:**

- This fix prevents the infinite loop and ensures correct retrieval of the `displayName`.
- Downstream systems relying on the display name will now receive accurate data.

**Additional Notes:**

- Link to the associated GitHub issue #40  