### PR TITLE
Ensure consistent artifact ID format

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
@@ -82,7 +82,7 @@ open class MavenPublishImpl : MavenPublish {
         names.takeLast(get { artifactIdElements }!!)
       } else {
         names
-      }.joinToString(separator = "-")
+      }.joinToString(separator = "-").replace(".", "-")
     }
 
   override val dependency: String


### PR DESCRIPTION
**Issue:**

Previously, the artifact ID used dots as separators. This change introduces inconsistency and potential issues with downstream systems.

**Fix:**

This pull request replaces all dots with dashes in the artifact ID string using the `joinToString` function with the `.replace(".", "-")` modifier. This ensures a consistent and more standardized format.

**Benefits:**

- Improved consistency across artifact IDs.
- Potential compatibility enhancements with downstream systems.
- Easier identification and handling of artifact IDs.