### PR TITLE
Ensure null check before depending on parent publish task

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/impl/MavenPublishUtils.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/impl/MavenPublishUtils.kt
@@ -142,8 +142,9 @@ private fun Project.createAndConfigureSubprojectPublishTask(maven: MavenPublish)
       project.childProjects.values.forEach { subproject ->
         val parentPublishTask = subproject.parent!!.tasks.findByName(taskName)
         subproject.afterEvaluate {
-          val publishTask = subproject.tasks.findByName("publish")
-          parentPublishTask?.dependsOn(publishTask)
+          subproject.tasks.findByName("publish")?.let { task ->
+            parentPublishTask?.dependsOn(task)
+          }
         }
       }
     }


### PR DESCRIPTION
**Summary:**

This pull request addresses a potential NullPointerException in the chained publishing functionality for subprojects. Previously, if a subproject didn't have a "publish" task, accessing the parent's "publish" task through `parentPublishTask?.dependsOn(task)` within the subproject could lead to an NPE.

**Change:**

This fix introduces a null check using `?.let { task -> ... }` to ensure the parent task exists before adding the dependency. This prevents the NPE and ensures reliable chained publishing behavior.

**Benefits:**

* **Improved Stability:** Eliminates the risk of NullPointerException during publishing.
* **Enhanced Robustness:** Makes chained publishing more resilient to unforeseen scenarios.
* **Clearer Code:** The null check adds clarity and avoids potential confusion.
