### PR TITLE
Add option for unique names using `enforceUniqueNames`

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -44,6 +44,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun getDescription ()Ljava/lang/String;
 	public abstract fun getDevelopers ()Ljava/util/List;
 	public abstract fun getDisplayName ()Ljava/lang/String;
+	public abstract fun getEnforceUniqueNames ()Z
 	public abstract fun getGroupId ()Ljava/lang/String;
 	public abstract fun getInceptionYear ()Ljava/lang/Integer;
 	public abstract fun getLicenses ()Ljava/util/List;
@@ -61,6 +62,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun setDescription (Ljava/lang/String;)V
 	public abstract fun setDevelopers (Ljava/util/List;)V
 	public abstract fun setDisplayName (Ljava/lang/String;)V
+	public abstract fun setEnforceUniqueNames (Z)V
 	public abstract fun setGroupId (Ljava/lang/String;)V
 	public abstract fun setInceptionYear (Ljava/lang/Integer;)V
 	public abstract fun setLicenses (Ljava/util/List;)V

--- a/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
@@ -26,6 +26,7 @@ import dev.teogor.winds.api.provider.Scm
 interface MavenPublish {
   var displayName: String?
   var name: String?
+  var enforceUniqueNames: Boolean
   var description: String?
   var groupId: String?
   val artifactId: String?

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -71,6 +71,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public fun getDescription ()Ljava/lang/String;
 	public fun getDevelopers ()Ljava/util/List;
 	public fun getDisplayName ()Ljava/lang/String;
+	public fun getEnforceUniqueNames ()Z
 	public fun getGroupId ()Ljava/lang/String;
 	public fun getInceptionYear ()Ljava/lang/Integer;
 	public fun getLicenses ()Ljava/util/List;
@@ -92,6 +93,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setDevelopers (Ljava/util/List;)V
 	public fun setDisplayName (Ljava/lang/String;)V
+	public fun setEnforceUniqueNames (Z)V
 	public fun setGroupId (Ljava/lang/String;)V
 	public fun setInceptionYear (Ljava/lang/Integer;)V
 	public fun setLicenses (Ljava/util/List;)V

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
@@ -32,6 +32,8 @@ open class MavenPublishImpl : MavenPublish {
   override var name: String? = null
     get() = field ?: getter { name }
 
+  override var enforceUniqueNames: Boolean = true
+
   override var description: String? = null
     get() = field ?: getter { description }
 
@@ -77,7 +79,13 @@ open class MavenPublishImpl : MavenPublish {
 
   override val artifactId: String?
     get() {
-      val names = gets { name }
+      val names = gets { name }.let {
+        if (enforceUniqueNames) {
+          it.distinct()
+        } else {
+          it
+        }
+      }
       return if (get { artifactIdElements } != null) {
         names.takeLast(get { artifactIdElements }!!)
       } else {
@@ -90,7 +98,13 @@ open class MavenPublishImpl : MavenPublish {
 
   override val completeName: String
     get() {
-      val names = gets { displayName }
+      val names = gets { displayName }.let {
+        if (enforceUniqueNames) {
+          it.distinct()
+        } else {
+          it
+        }
+      }
       return names.joinToString(separator = " ")
     }
 

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/utils/WindsExtensions.kt
@@ -183,7 +183,7 @@ inline fun Project.collectModulesInfo(
       dependencyGatheringType = docsGenerator.dependencyGatheringType,
     )
 
-    val mavenPublish = winds.mavenPublish
+    val mavenPublish = winds.mavenPublish as MavenPublishImpl
     val moduleInfo = ModuleInfo(
       completeName = mavenPublish.completeName,
       name = mavenPublish.name ?: "",
@@ -195,7 +195,11 @@ inline fun Project.collectModulesInfo(
       path = path,
       dependencies = dependencies,
       canBePublished = mavenPublish.canBePublished,
-      names = (mavenPublish as MavenPublishImpl).gets { displayName },
+      names = if (mavenPublish.enforceUniqueNames) {
+        mavenPublish.gets { displayName }.distinct()
+      } else {
+        mavenPublish.gets { displayName }
+      },
     )
 
     onModuleInfo(moduleInfo)


### PR DESCRIPTION
**Summary:**

This pull request enhances the `completeName` property to ensure unique names when the `enforceUniqueNames` flag is set. It achieves this by conditionally applying the `distinct()` function to the `names` collection before generating the final complete name.

**Details:**

- The code now checks the `enforceUniqueNames` flag within the `completeName` getter.
- If `enforceUniqueNames` is true, the `names` collection is filtered for unique names using `distinct()`.
- This ensures that only distinct names are included in the final `completeName` value.

**Benefits:**

- Prevents duplicate names from appearing in the `completeName` output.
- Provides flexibility to control name uniqueness based on specific requirements.
- Improves data consistency and potential downstream processing.
