### PR TITLE
Integrate `Contributor` interface and enable custom contributors in Maven publications

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -28,6 +28,9 @@ public abstract interface class dev/teogor/winds/api/DocsGenerator : dev/teogor/
 }
 
 public abstract interface class dev/teogor/winds/api/MavenPublish {
+	public abstract fun addContributor (Ldev/teogor/winds/api/model/Contributor;)V
+	public abstract fun addContributor (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun addContributors ([Ldev/teogor/winds/api/model/Contributor;)V
 	public abstract fun addDeveloper (Ldev/teogor/winds/api/model/Developer;)V
 	public abstract fun addDeveloper (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun addDevelopers ([Ldev/teogor/winds/api/model/Developer;)V
@@ -39,6 +42,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun getBomOptions ()Ldev/teogor/winds/api/model/BomOptions;
 	public abstract fun getCanBePublished ()Z
 	public abstract fun getCompleteName ()Ljava/lang/String;
+	public abstract fun getContributors ()Ljava/util/List;
 	public abstract fun getDependency ()Ljava/lang/String;
 	public abstract fun getDependencyBoM ()Ljava/lang/String;
 	public abstract fun getDescription ()Ljava/lang/String;
@@ -59,6 +63,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun setArtifactIdElements (Ljava/lang/Integer;)V
 	public abstract fun setBomOptions (Ldev/teogor/winds/api/model/BomOptions;)V
 	public abstract fun setCanBePublished (Z)V
+	public abstract fun setContributors (Ljava/util/List;)V
 	public abstract fun setDescription (Ljava/lang/String;)V
 	public abstract fun setDevelopers (Ljava/util/List;)V
 	public abstract fun setDisplayName (Ljava/lang/String;)V
@@ -163,6 +168,44 @@ public final class dev/teogor/winds/api/model/BomOptions {
 	public fun hashCode ()I
 	public final fun setAcceptedModules (Ljava/util/List;)V
 	public final fun setAcceptedPaths (Ljava/util/List;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/teogor/winds/api/model/Contributor {
+	public abstract fun getEmail ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getOrganization ()Ljava/lang/String;
+	public abstract fun getOrganizationUrl ()Ljava/lang/String;
+	public abstract fun getProperties ()Ljava/util/Map;
+	public abstract fun getRoles ()Ljava/util/List;
+	public abstract fun getTimezone ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/ContributorImpl : dev/teogor/winds/api/model/Contributor {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)Ldev/teogor/winds/api/model/ContributorImpl;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/ContributorImpl;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Ldev/teogor/winds/api/model/ContributorImpl;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEmail ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun getOrganization ()Ljava/lang/String;
+	public fun getOrganizationUrl ()Ljava/lang/String;
+	public fun getProperties ()Ljava/util/Map;
+	public fun getRoles ()Ljava/util/List;
+	public fun getTimezone ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
@@ -17,6 +17,8 @@
 package dev.teogor.winds.api
 
 import dev.teogor.winds.api.model.BomOptions
+import dev.teogor.winds.api.model.Contributor
+import dev.teogor.winds.api.model.ContributorImpl
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.DeveloperImpl
 import dev.teogor.winds.api.model.LicenseType
@@ -40,17 +42,21 @@ interface MavenPublish {
   var scmDeveloperConnection: String?
   var version: Version?
   var canBePublished: Boolean
-  var licenses: List<LicenseType>?
+  var contributors: List<Contributor>?
   var developers: List<Developer>?
+  var licenses: List<LicenseType>?
   var bomOptions: BomOptions?
   val isBoM: Boolean
   var inceptionYear: Int?
   val scm: Scm
 
-  fun addLicense(license: LicenseType)
+  fun addContributor(contributor: Contributor)
+  fun addContributors(vararg contributors: Contributor)
+  fun addContributor(init: ContributorImpl.() -> Unit)
   fun addDeveloper(developer: Developer)
   fun addDevelopers(vararg developers: Developer)
   fun addDeveloper(init: DeveloperImpl.() -> Unit)
+  fun addLicense(license: LicenseType)
   fun defineBoM(init: BomOptions.() -> Unit = {})
   fun sourceControlManagement(scm: Scm)
 }

--- a/api/src/main/kotlin/dev/teogor/winds/api/model/Contributor.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/model/Contributor.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.api.model
+
+import org.gradle.api.publish.maven.MavenPomContributor
+
+/**
+ * A contributor to a Maven publication.
+ *
+ * This interface represents a person or entity involved in the creation or development
+ * of a Maven artifact. It provides properties for basic contributor information such as
+ * name, email, URL, organization, roles, and timezone.
+ *
+ * Additionally, it allows specifying custom properties using a key-value map.
+ *
+ * @see MavenPomContributor for the original interface definition.
+ */
+interface Contributor {
+
+  /**
+   * The name of the contributor.
+   */
+  val name: String
+
+  /**
+   * The email address of the contributor.
+   */
+  val email: String
+
+  /**
+   * The URL of the contributor.
+   */
+  val url: String
+
+  /**
+   * The organization name of the contributor.
+   */
+  val organization: String
+
+  /**
+   * The URL of the contributor's organization.
+   */
+  val organizationUrl: String
+
+  /**
+   * The roles of the contributor in the project (e.g., "developer", "architect").
+   */
+  val roles: List<String>
+
+  /**
+   * The timezone of the contributor.
+   */
+  val timezone: String
+
+  /**
+   * Additional properties of the contributor represented as a key-value map.
+   */
+  val properties: Map<String, String>
+}
+
+/**
+ * An implementation of the `Contributor` interface using String properties.
+ *
+ * This class provides concrete implementations for all properties of the [Contributor]
+ * interface using String types.
+ *
+ * It is a convenient way to represent a contributor with basic information.
+ */
+data class ContributorImpl(
+  override val name: String = "",
+  override val email: String = "",
+  override val url: String = "",
+  override val organization: String = "",
+  override val organizationUrl: String = "",
+  override val roles: List<String> = emptyList(),
+  override val timezone: String = "",
+  override val properties: Map<String, String> = emptyMap(),
+) : Contributor

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -30,6 +30,13 @@ public final class dev/teogor/winds/common/ErrorId$GenericError : dev/teogor/win
 	public fun getErrorIdString ()Ljava/lang/String;
 }
 
+public final class dev/teogor/winds/common/ErrorId$PomContributorError : dev/teogor/winds/common/ErrorId {
+	public static final field INSTANCE Ldev/teogor/winds/common/ErrorId$PomContributorError;
+	public fun getErrorId ()I
+	public fun getErrorIdFormatted ()Ljava/lang/String;
+	public fun getErrorIdString ()Ljava/lang/String;
+}
+
 public final class dev/teogor/winds/common/ErrorId$PomDeveloperError : dev/teogor/winds/common/ErrorId {
 	public static final field INSTANCE Ldev/teogor/winds/common/ErrorId$PomDeveloperError;
 	public fun getErrorId ()I

--- a/common/src/main/kotlin/dev/teogor/winds/common/ErrorIds.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/ErrorIds.kt
@@ -43,4 +43,8 @@ sealed interface ErrorId {
   object PomDeveloperError : ErrorId {
     override val errorId: Int = 1004
   }
+
+  object PomContributorError : ErrorId {
+    override val errorId: Int = 1005
+  }
 }

--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
@@ -17,10 +17,12 @@
 package dev.teogor.winds.common.utils
 
 import dev.teogor.winds.api.MavenPublish
+import dev.teogor.winds.api.model.Contributor
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.common.ErrorId
 import org.gradle.api.publish.maven.MavenPom
+import org.gradle.api.publish.maven.MavenPomContributorSpec
 import org.gradle.api.publish.maven.MavenPomDeveloperSpec
 import org.gradle.api.publish.maven.MavenPomLicenseSpec
 
@@ -32,7 +34,9 @@ fun attachMavenData(pom: MavenPom, mavenPublish: MavenPublish) {
     url.set(mavenPublish.url)
 
     contributors {
-      // TODO maven contributors
+      mavenPublish.contributors?.toContributorSpec(
+        mavenPomContributorSpec = it,
+      )
     }
 
     developers {
@@ -51,6 +55,23 @@ fun attachMavenData(pom: MavenPom, mavenPublish: MavenPublish) {
       it.url.set(mavenPublish.scmUrl)
       it.connection.set(mavenPublish.scmConnection)
       it.developerConnection.set(mavenPublish.scmDeveloperConnection)
+    }
+  }
+}
+
+private fun List<Contributor>.toContributorSpec(
+  mavenPomContributorSpec: MavenPomContributorSpec,
+) {
+  forEach { contributor ->
+    mavenPomContributorSpec.contributor {
+      it.name.set(contributor.name)
+      it.email.set(contributor.email)
+      it.url.set(contributor.url)
+      it.organization.set(contributor.organization)
+      it.organizationUrl.set(contributor.organizationUrl)
+      it.roles.set(contributor.roles)
+      it.timezone.set(contributor.timezone)
+      it.properties.set(contributor.properties)
     }
   }
 }
@@ -101,6 +122,16 @@ private fun developerError(): Nothing = error(
   If you think this is an error, please [create an issue](https://github.com/teogor/winds) to assist in resolving this matter.
   Be sure to include the following error ID in your report to help us identify and address the issue:
   ${ErrorId.PomDeveloperError.getErrorIdString()}
+  Thank you for your contribution to improving Winds!
+  """.trimIndent(),
+)
+
+private fun contributorError(): Nothing = error(
+  """
+  Uh-oh! At least a contributor must be provided for your module. Please add contributor information in the `mavenPublish` block within the `winds` extension.
+  If you think this is an error, please [create an issue](https://github.com/teogor/winds) to assist in resolving this matter.
+  Be sure to include the following error ID in your report to help us identify and address the issue:
+  ${ErrorId.PomContributorError.getErrorIdString()}
   Thank you for your contribution to improving Winds!
   """.trimIndent(),
 )

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -3,6 +3,7 @@ import dev.teogor.winds.api.MavenPublish
 import dev.teogor.winds.api.getValue
 import dev.teogor.winds.api.model.DependencyType
 import dev.teogor.winds.api.model.Developer
+import dev.teogor.winds.api.model.Contributor
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.api.provider.Scm
 import dev.teogor.winds.gradle.utils.afterWindsPluginConfiguration
@@ -64,6 +65,8 @@ winds {
     addLicense(LicenseType.APACHE_2_0)
 
     addDeveloper(TeogorDeveloper())
+
+    addContributor(TeogorContributor())
   }
 
   docsGenerator {
@@ -101,6 +104,17 @@ afterWindsPluginConfiguration { winds ->
     }
   }
 }
+
+data class TeogorContributor(
+  override val name: String = "Teodor Grigor",
+  override val email: String = "open-source@teogor.dev",
+  override val url: String = "https://teogor.dev",
+  override val roles: List<String> = listOf("Code Owner", "Developer", "Designer", "Maintainer"),
+  override val timezone: String = "UTC+2",
+  override val organization: String = "Teogor",
+  override val organizationUrl: String = "https://github.com/teogor",
+  override val properties: Map<String, String> = emptyMap(),
+) : Contributor
 
 data class TeogorDeveloper(
   override val id: String = "teogor",

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -54,6 +54,9 @@ public final class dev/teogor/winds/api/impl/DocsGeneratorImpl : dev/teogor/wind
 
 public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/MavenPublish {
 	public fun <init> ()V
+	public fun addContributor (Ldev/teogor/winds/api/model/Contributor;)V
+	public fun addContributor (Lkotlin/jvm/functions/Function1;)V
+	public fun addContributors ([Ldev/teogor/winds/api/model/Contributor;)V
 	public fun addDeveloper (Ldev/teogor/winds/api/model/Developer;)V
 	public fun addDeveloper (Lkotlin/jvm/functions/Function1;)V
 	public fun addDevelopers ([Ldev/teogor/winds/api/model/Developer;)V
@@ -66,6 +69,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public fun getCanBePublished ()Z
 	public fun getCompleteName ()Ljava/lang/String;
 	public final fun getConfigured ()Z
+	public fun getContributors ()Ljava/util/List;
 	public fun getDependency ()Ljava/lang/String;
 	public fun getDependencyBoM ()Ljava/lang/String;
 	public fun getDescription ()Ljava/lang/String;
@@ -90,6 +94,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public fun setBomOptions (Ldev/teogor/winds/api/model/BomOptions;)V
 	public fun setCanBePublished (Z)V
 	public final fun setConfigured (Z)V
+	public fun setContributors (Ljava/util/List;)V
 	public fun setDescription (Ljava/lang/String;)V
 	public fun setDevelopers (Ljava/util/List;)V
 	public fun setDisplayName (Ljava/lang/String;)V

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
@@ -18,6 +18,8 @@ package dev.teogor.winds.api.impl
 
 import dev.teogor.winds.api.MavenPublish
 import dev.teogor.winds.api.model.BomOptions
+import dev.teogor.winds.api.model.Contributor
+import dev.teogor.winds.api.model.ContributorImpl
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.DeveloperImpl
 import dev.teogor.winds.api.model.LicenseType
@@ -60,11 +62,14 @@ open class MavenPublishImpl : MavenPublish {
 
   override var canBePublished: Boolean = true
 
-  override var licenses: List<LicenseType>? = null
-    get() = field ?: getter { licenses }
+  override var contributors: List<Contributor>? = null
+    get() = field ?: getter { contributors }
 
   override var developers: List<Developer>? = null
     get() = field ?: getter { developers }
+
+  override var licenses: List<LicenseType>? = null
+    get() = field ?: getter { licenses }
 
   override var bomOptions: BomOptions? = null
     get() = field ?: getter { bomOptions }
@@ -113,8 +118,13 @@ open class MavenPublishImpl : MavenPublish {
 
   var configured: Boolean = false
 
-  override fun addLicense(license: LicenseType) {
-    licenses = (licenses ?: emptyList()) + license
+  override fun addContributors(vararg contributors: Contributor) {
+    this.contributors = (this.contributors ?: emptyList()) + contributors
+  }
+
+  override fun addContributor(init: ContributorImpl.() -> Unit) {
+    val contributor = ContributorImpl().apply(init)
+    contributors = (contributors ?: emptyList()) + contributor
   }
 
   override fun addDeveloper(developer: Developer) {
@@ -128,6 +138,14 @@ open class MavenPublishImpl : MavenPublish {
   override fun addDeveloper(init: DeveloperImpl.() -> Unit) {
     val developer = DeveloperImpl().apply(init)
     developers = (developers ?: emptyList()) + developer
+  }
+
+  override fun addLicense(license: LicenseType) {
+    licenses = (licenses ?: emptyList()) + license
+  }
+
+  override fun addContributor(contributor: Contributor) {
+    contributors = (contributors ?: emptyList()) + contributor
   }
 
   override fun defineBoM(init: BomOptions.() -> Unit) {


### PR DESCRIPTION
### Integrate `Contributor` interface and enable custom contributors in Maven publications

This pull request introduces the `Contributor` interface and its implementation `ContributorImpl` to provide more flexibility and customization for representing contributors in Maven publications compared to the existing `MavenPomContributor`.

**Key improvements:**

* **Flexible contributor information:** Define contributor details like name, email, URL, organization, roles, timezone, and optional custom properties using key-value pairs.
* **Easier usage:** Add contributors directly to the `mavenPublish` block like `addContributor(TeogorContributor())`.
* **Kotlin data class:** Leverages Kotlin data classes for concise and expressive contributor representation.

**Example usage:**

```kotlin
winds {
  mavenPublish {
    // Existing configuration...

    // Add a custom contributor (replace with your actual contributor):
    addContributor(TeogorContributor())
  }
}
```

**TeogorContributor implementation:**

This example `TeogorContributor` class demonstrates how to utilize the `Contributor` interface with pre-defined information:

```kotlin
data class TeogorContributor(
  override val name: String = "Teodor Grigor",
  override val email: String = "open-source@teogor.dev",
  override val url: String = "[https://teogor.dev](https://teogor.dev)",
  override val roles: List<String> = listOf("Code Owner", "Developer", "Designer", "Maintainer"),
  override val timezone: String = "UTC+2",
  override val organization: String = "Teogor",
  override val organizationUrl: String = "[https://github.com/teogor](https://github.com/teogor)",
  override val properties: Map<String, String> = emptyMap(),
) : Contributor
```

**Changes:**

* This PR introduces the `Contributor` interface and its implementation `ContributorImpl`.
* Existing code using `MavenPomContributor` needs to be updated to use the new `Contributor` interface.

We believe this improvement enhances flexibility and maintainability for contributor management in Maven publications.
