### PR TITLE
Integrate `IssueManagement` interface and enable custom issue management in Maven publications

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -51,6 +51,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun getEnforceUniqueNames ()Z
 	public abstract fun getGroupId ()Ljava/lang/String;
 	public abstract fun getInceptionYear ()Ljava/lang/Integer;
+	public abstract fun getIssueManagement ()Ldev/teogor/winds/api/model/IssueManagement;
 	public abstract fun getLicenses ()Ljava/util/List;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getScm ()Ldev/teogor/winds/api/provider/Scm;
@@ -60,6 +61,7 @@ public abstract interface class dev/teogor/winds/api/MavenPublish {
 	public abstract fun getUrl ()Ljava/lang/String;
 	public abstract fun getVersion ()Ldev/teogor/winds/api/model/Version;
 	public abstract fun isBoM ()Z
+	public abstract fun issueManagement (Ldev/teogor/winds/api/model/IssueManagement;)V
 	public abstract fun setArtifactIdElements (Ljava/lang/Integer;)V
 	public abstract fun setBomOptions (Ldev/teogor/winds/api/model/BomOptions;)V
 	public abstract fun setCanBePublished (Z)V
@@ -299,6 +301,91 @@ public final class dev/teogor/winds/api/model/DeveloperImpl : dev/teogor/winds/a
 	public fun setRoles (Ljava/util/List;)V
 	public fun setTimezone (Ljava/lang/String;)V
 	public fun setUrl (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class dev/teogor/winds/api/model/IssueManagement {
+	public abstract fun getSystem ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/IssueManagement$Bugzilla : dev/teogor/winds/api/model/IssueManagement {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/winds/api/model/IssueManagement$Bugzilla;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/IssueManagement$Bugzilla;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/winds/api/model/IssueManagement$Bugzilla;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComponent ()Ljava/lang/String;
+	public final fun getProduct ()Ljava/lang/String;
+	public final fun getServerUrl ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/IssueManagement$Git : dev/teogor/winds/api/model/IssueManagement {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/winds/api/model/IssueManagement$Git;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/IssueManagement$Git;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/winds/api/model/IssueManagement$Git;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwner ()Ljava/lang/String;
+	public final fun getRepo ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/IssueManagement$GitLab : dev/teogor/winds/api/model/IssueManagement {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/winds/api/model/IssueManagement$GitLab;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/IssueManagement$GitLab;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/winds/api/model/IssueManagement$GitLab;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getProject ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/IssueManagement$Jira : dev/teogor/winds/api/model/IssueManagement {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/winds/api/model/IssueManagement$Jira;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/IssueManagement$Jira;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/winds/api/model/IssueManagement$Jira;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProjectKey ()Ljava/lang/String;
+	public final fun getServerUrl ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/model/IssueManagement$Redmine : dev/teogor/winds/api/model/IssueManagement {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/teogor/winds/api/model/IssueManagement$Redmine;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/model/IssueManagement$Redmine;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/teogor/winds/api/model/IssueManagement$Redmine;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public final fun getProjectId ()Ljava/lang/String;
+	public fun getSystem ()Ljava/lang/String;
+	public fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/MavenPublish.kt
@@ -21,6 +21,7 @@ import dev.teogor.winds.api.model.Contributor
 import dev.teogor.winds.api.model.ContributorImpl
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.DeveloperImpl
+import dev.teogor.winds.api.model.IssueManagement
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.api.model.Version
 import dev.teogor.winds.api.provider.Scm
@@ -49,6 +50,7 @@ interface MavenPublish {
   val isBoM: Boolean
   var inceptionYear: Int?
   val scm: Scm
+  val issueManagement: IssueManagement?
 
   fun addContributor(contributor: Contributor)
   fun addContributors(vararg contributors: Contributor)
@@ -59,4 +61,5 @@ interface MavenPublish {
   fun addLicense(license: LicenseType)
   fun defineBoM(init: BomOptions.() -> Unit = {})
   fun sourceControlManagement(scm: Scm)
+  fun issueManagement(issueManagement: IssueManagement)
 }

--- a/api/src/main/kotlin/dev/teogor/winds/api/model/IssueManagement.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/model/IssueManagement.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.api.model
+
+import org.gradle.api.publish.maven.MavenPomIssueManagement
+
+/**
+ * Represents the issue management system of a Maven publication.
+ *
+ * This interface provides properties for the name and URL of the issue management
+ * system used for tracking and managing issues related to the publication.
+ *
+ * @see MavenPomIssueManagement for the original Gradle API interface definition.
+ */
+interface IssueManagement {
+
+  /**
+   * The name of the issue management system.
+   */
+  val system: String
+
+  /**
+   * The URL of the issue management system for this publication.
+   */
+  val url: String
+
+  /**
+   * Represents a GitHub repository as the issue management system.
+   *
+   * @param repo The name of the GitHub repository (e.g., "teogor/winds").
+   * @param owner The owner of the GitHub repository (e.g., "teogor").
+   */
+  data class Git(
+    val repo: String,
+    val owner: String,
+  ) : IssueManagement {
+    override val system: String = "GitHub Issues"
+    override val url: String = "https://github.com/$owner/$repo/issues"
+  }
+
+  /**
+   * Represents a GitLab project as the issue management system.
+   *
+   * @param project The name of the GitLab project (e.g., "winds").
+   * @param group The group or organization containing the project (optional).
+   */
+  data class GitLab(
+    val project: String,
+    val group: String = "",
+  ) : IssueManagement {
+    override val system: String = "GitLab Issues"
+    override val url: String = "https://gitlab.com/$group/$project/issues"
+  }
+
+  /**
+   * Represents a Jira project as the issue management system.
+   *
+   * @param projectKey The key of the Jira project (e.g., "WINDS").
+   * @param serverUrl The URL of the Jira server (optional, defaults to Jira Cloud).
+   */
+  data class Jira(
+    val projectKey: String,
+    val serverUrl: String = "https://issues.atlassian.com",
+  ) : IssueManagement {
+    override val system: String = "Jira"
+    override val url: String = "$serverUrl/browse/$projectKey"
+  }
+
+  /**
+   * Represents a Bugzilla product as the issue management system.
+   *
+   * @param product The name of the Bugzilla product (e.g., "Winds").
+   * @param component The component within the product (optional).
+   * @param serverUrl The URL of the Bugzilla server.
+   */
+  data class Bugzilla(
+    val product: String,
+    val component: String = "",
+    val serverUrl: String,
+  ) : IssueManagement {
+    override val system: String = "Bugzilla"
+    override val url: String = "$serverUrl/buglist.cgi?product=$product&component=$component"
+  }
+
+  /**
+   * Represents a Redmine project as the issue management system.
+   *
+   * @param projectId The ID or alias of the Redmine project.
+   * @param baseUrl The base URL of the Redmine server.
+   */
+  data class Redmine(
+    val projectId: String,
+    val baseUrl: String,
+  ) : IssueManagement {
+    override val system: String = "Redmine"
+    override val url: String = "$baseUrl/projects/$projectId/issues"
+  }
+}

--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/MavenPomUtils.kt
@@ -56,6 +56,15 @@ fun attachMavenData(pom: MavenPom, mavenPublish: MavenPublish) {
       it.connection.set(mavenPublish.scmConnection)
       it.developerConnection.set(mavenPublish.scmDeveloperConnection)
     }
+
+    issueManagement { mavenPomIssueManagement ->
+      mavenPublish.issueManagement?.system?.let {
+        mavenPomIssueManagement.system.set(it)
+      }
+      mavenPublish.issueManagement?.url?.let {
+        mavenPomIssueManagement.url.set(it)
+      }
+    }
   }
 }
 

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -6,6 +6,7 @@ import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.Contributor
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.api.provider.Scm
+import dev.teogor.winds.api.model.IssueManagement
 import dev.teogor.winds.gradle.utils.afterWindsPluginConfiguration
 import dev.teogor.winds.gradle.utils.attachTo
 
@@ -57,6 +58,13 @@ winds {
 
     sourceControlManagement(
       Scm.Git(
+        repo = "winds",
+        owner = "teogor",
+      ),
+    )
+
+    issueManagement(
+      IssueManagement.Git(
         repo = "winds",
         owner = "teogor",
       ),

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -78,6 +78,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public fun getEnforceUniqueNames ()Z
 	public fun getGroupId ()Ljava/lang/String;
 	public fun getInceptionYear ()Ljava/lang/Integer;
+	public fun getIssueManagement ()Ldev/teogor/winds/api/model/IssueManagement;
 	public fun getLicenses ()Ljava/util/List;
 	public final fun getMavenPublishOptions ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
@@ -90,6 +91,7 @@ public class dev/teogor/winds/api/impl/MavenPublishImpl : dev/teogor/winds/api/M
 	public final fun gets (Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public final fun getter (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun isBoM ()Z
+	public fun issueManagement (Ldev/teogor/winds/api/model/IssueManagement;)V
 	public fun setArtifactIdElements (Ljava/lang/Integer;)V
 	public fun setBomOptions (Ldev/teogor/winds/api/model/BomOptions;)V
 	public fun setCanBePublished (Z)V

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/MavenPublishImpl.kt
@@ -22,6 +22,7 @@ import dev.teogor.winds.api.model.Contributor
 import dev.teogor.winds.api.model.ContributorImpl
 import dev.teogor.winds.api.model.Developer
 import dev.teogor.winds.api.model.DeveloperImpl
+import dev.teogor.winds.api.model.IssueManagement
 import dev.teogor.winds.api.model.LicenseType
 import dev.teogor.winds.api.model.Version
 import dev.teogor.winds.api.provider.Scm
@@ -118,6 +119,14 @@ open class MavenPublishImpl : MavenPublish {
 
   var configured: Boolean = false
 
+  private var _scm: Scm? = null
+  override val scm: Scm
+    get() = _scm ?: error("no SCM provided")
+
+  private var _issueManagement: IssueManagement? = null
+  override val issueManagement: IssueManagement?
+    get() = _issueManagement
+
   override fun addContributors(vararg contributors: Contributor) {
     this.contributors = (this.contributors ?: emptyList()) + contributors
   }
@@ -152,14 +161,15 @@ open class MavenPublishImpl : MavenPublish {
     bomOptions = (bomOptions ?: BomOptions()).apply(init)
   }
 
-  private var _scm: Scm? = null
-  override val scm: Scm
-    get() = _scm ?: error("no SCM provided")
   override fun sourceControlManagement(scm: Scm) {
     _scm = scm
     scmConnection = scm.connection
     scmDeveloperConnection = scm.developerConnection
     scmUrl = scm.url
+  }
+
+  override fun issueManagement(issueManagement: IssueManagement) {
+    _issueManagement = issueManagement
   }
 
   fun <T> getter(selector: MavenPublish.() -> T?): T? {


### PR DESCRIPTION
This pull request introduces the `IssueManagement` interface and its nested data classes to provide flexible configuration of the issue management system used in Maven publications. This enhances customization and streamlines management of issue tracking for diverse platforms.

**Key improvements:**

* **Flexible issue management:** Define the issue management system (e.g., GitHub, GitLab, Jira) used for your project using dedicated data classes like `Git`, `GitLab`, `Jira`, etc.
* **Simplified configuration:** Configure the issue management system directly within the `mavenPublish` block using the `issueManagement` method, as demonstrated in the example:

```kotlin
winds {
  mavenPublish {
    // Other configuration...

    // Set issue management using a Git repository:
    issueManagement(IssueManagement.Git(
      repo = "winds",
      owner = "teogor",
    ))
  }
}
```

* **Supported systems:** Currently includes data classes for GitHub, GitLab, Jira, Bugzilla, and Redmine. Additional platform integrations can be easily added in the future.

**Changes:**

* Introduces the `IssueManagement` interface and its nested data classes.
* Updates the `mavenPublish` block to accept an `issueManagement` configuration parameter.
* Existing code using the original `MavenPomIssueManagement` interface will need to be updated to use the new `IssueManagement` approach.

**Benefits:**

* Increased flexibility and adaptability for issue management configuration.
* Improved clarity and maintainability of the code.
* Supports various popular issue tracking platforms.

We believe this improvement offers significant advantages for managing issue tracking in your Maven publications.