### PR TITLE
Publish Winds v1.0.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To implement the Winds plugin, add the following plugin ID to your build.gradle 
 
 ```kotlin
 plugins {
-  id "dev.teogor.winds" version "1.0.0-beta02"
+  id "dev.teogor.winds" version "1.0.0-beta03"
 }
 ```
 
@@ -45,7 +45,7 @@ library:
 
 ```kotlin
 plugins {
-  id "dev.teogor.winds" version "1.0.0-beta02"
+  id "dev.teogor.winds" version "1.0.0-beta03"
 }
 
 winds {
@@ -72,7 +72,7 @@ winds {
 # License
 
 ```xml
-Designed and developed by 2023 teogor (Teodor Grigor)
+  Designed and developed by 2023 teogor (Teodor Grigor)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,9 @@ plugins {
 }
 
 // Explicitly set the group and version for all subprojects
-subprojects {
+allprojects {
   group = "dev.teogor.winds"
-  version = "1.0.0-beta02"
+  version = "1.0.0-beta03"
 }
 
 val ktlintVersion = "0.50.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ To implement the Winds plugin, add the following plugin ID to your build.gradle 
 
     ```kotlin
     plugins {
-      id("dev.teogor.winds") version "1.0.0-beta02"
+      id("dev.teogor.winds") version "1.0.0-beta03"
     }
     ```
 
@@ -41,7 +41,7 @@ To implement the Winds plugin, add the following plugin ID to your build.gradle 
 
     ```groovy
     plugins {
-      id 'dev.teogor.winds' version '1.0.0-beta02'
+      id 'dev.teogor.winds' version '1.0.0-beta03'
     }
     ```
 
@@ -81,7 +81,7 @@ detailed explanations, examples, and best practices for using the library effect
 # License
 
 ```xml
-Designed and developed by 2023 teogor (Teodor Grigor)
+  Designed and developed by 2023 teogor (Teodor Grigor)
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -17,8 +17,9 @@ Winds build and publish libraries and applications for multiple platforms, simpl
 
 |   Latest Update   | Stable Release | Beta Release | Alpha Release |
 |:-----------------:|:--------------:|:------------:|:-------------:|
-| February 19, 2024 |       -        |      -       | 1.0.0-beta02  |
-| February 08, 2024 |       -        |      -       | 1.0.0-beta01  |
+| February 27, 2024 |       -        | 1.0.0-beta03 |       -       |
+| February 19, 2024 |       -        | 1.0.0-beta02 |       -       |
+| February 08, 2024 |       -        | 1.0.0-beta01 |       -       |
 | November 25, 2023 |       -        |      -       | 1.0.0-alpha04 |
 | November 20, 2023 |       -        |      -       | 1.0.0-alpha03 |
 | November 08, 2023 |       -        |      -       | 1.0.0-alpha02 |
@@ -35,7 +36,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```kotlin
     plugins {
-      id("dev.teogor.winds") version "1.0.0-beta02"
+      id("dev.teogor.winds") version "1.0.0-beta03"
     }
     ```
 
@@ -43,7 +44,7 @@ Add the dependencies for the artifacts you need in the `build.gradle` file for y
 
     ```groovy
     plugins {
-      id 'dev.teogor.winds' version '1.0.0-beta02'
+      id 'dev.teogor.winds' version '1.0.0-beta03'
     }
     ```
 
@@ -57,6 +58,17 @@ existing issue by clicking the star button.
 [Create a new issue](https://github.com/teogor/winds/issues/new){ .md-button }
 
 ### Version 1.0.0
+
+#### Version 1.0.0-beta03
+
+February 19, 2024
+
+`dev.teogor.winds:winds-*:1.0.0-beta03` is
+released. [Version 1.0.0-beta03 contains these commits.](https://github.com/teogor/winds/compare/1.0.0-beta02...1.0.0-beta03)
+
+**Enhancement**
+
+* Integrate ([#52](https://github.com/teogor/winds/pull/52)) by [@teogor](https://github.com/teogor)
 
 #### Version 1.0.0-beta02
 

--- a/docs/releases/changelog/1.0.0-beta02.md
+++ b/docs/releases/changelog/1.0.0-beta02.md
@@ -1,0 +1,11 @@
+[//]: # (This file was automatically generated - do not edit)
+
+# Version 1.0.0-beta02
+
+## Latest SDK versions
+
+| Status |                Service or Product                |       Gradle dependency       | Latest version |
+|:------:|:------------------------------------------------:|:-----------------------------:|:--------------:|
+|   🧪   |       [Winds API](../../../reference/api)        |  dev.teogor.winds:winds-api   |  1.0.0-beta02  |
+|   🧪   |    [Winds Common](../../../reference/common)     | dev.teogor.winds:winds-common |  1.0.0-beta02  |
+|   🧪   | [Winds Plugin](../../../reference/gradle-plugin) |       dev.teogor.winds        |  1.0.0-beta02  |

--- a/docs/releases/changelog/1.0.0-beta03.md
+++ b/docs/releases/changelog/1.0.0-beta03.md
@@ -1,0 +1,11 @@
+[//]: # (This file was automatically generated - do not edit)
+
+# Version 1.0.0-beta03
+
+## Latest SDK versions
+
+| Status |                Service or Product                |       Gradle dependency       | Latest version |
+|:------:|:------------------------------------------------:|:-----------------------------:|:--------------:|
+|   🧪   |       [Winds API](../../../reference/api)        |  dev.teogor.winds:winds-api   |  1.0.0-beta03  |
+|   🧪   |    [Winds Common](../../../reference/common)     | dev.teogor.winds:winds-common |  1.0.0-beta03  |
+|   🧪   | [Winds Plugin](../../../reference/gradle-plugin) |       dev.teogor.winds        |  1.0.0-beta03  |

--- a/docs/releases/implementation.md
+++ b/docs/releases/implementation.md
@@ -4,7 +4,7 @@
 
 ### Latest Version
 
-The latest release is [`1.0.0-beta02`](../releases.md)
+The latest release is [`1.0.0-beta03`](../releases.md)
 
 ### Plugin Releases
 
@@ -12,6 +12,7 @@ Here's a summary of the latest versions:
 
 |    Version    |               Release Notes                | Release Date |
 |:-------------:|:------------------------------------------:|:------------:|
+| 1.0.0-beta03  | [changelog 🔗](changelog/1.0.0-beta03.md)  | 27 Feb 2024  |
 | 1.0.0-beta02  | [changelog 🔗](changelog/1.0.0-beta02.md)  | 19 Feb 2024  |
 | 1.0.0-beta01  | [changelog 🔗](changelog/1.0.0-beta01.md)  | 08 Feb 2024  |
 | 1.0.0-alpha04 | [changelog 🔗](changelog/1.0.0-alpha04.md) | 24 Nov 2023  |
@@ -30,7 +31,7 @@ TOML format.
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    teogor-winds = "1.0.0-beta02"
+    teogor-winds = "1.0.0-beta03"
 
     [plugins]
     teogor-winds = { id = "dev.teogor.winds", version.ref = "teogor-winds" }
@@ -40,7 +41,7 @@ TOML format.
 
     ```toml title="gradle/libs.versions.toml"
     [versions]
-    teogor-winds = "1.0.0-beta02"
+    teogor-winds = "1.0.0-beta03"
 
     [libraries]
     teogor-winds-api = { module = "dev.teogor.winds:api", version.ref = "teogor-winds" }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -75,7 +75,7 @@ gradlePlugin {
 }
 
 buildConfig {
-  packageName("dev.teogor.winds")
+  packageName(group.toString())
 
   buildConfigField("String", "NAME", "\"${group}\"")
   buildConfigField("String", "VERSION", "\"${version}\"")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - releases.md
     - Implementation: releases/implementation.md
     - Changelog:
+      - 1.0.0-beta03: releases/changelog/1.0.0-beta03.md
       - 1.0.0-beta02: releases/changelog/1.0.0-beta02.md
       - 1.0.0-beta01: releases/changelog/1.0.0-beta01.md
       - 1.0.0-alpha04: releases/changelog/1.0.0-alpha04.md


### PR DESCRIPTION
## Release Winds v1.0.0-beta03: Plugin and Artifacts

This pull request prepares the release of Winds version 1.0.0-beta03, including the following updates:

- **Version Updates:**
    - Updates the `dev.teogor.winds` plugin version to `1.0.0-beta03`.
    - Bumps the versions of `dev.teogor.winds:api` and `dev.teogor.winds:common` to `1.0.0-beta03`.