### PR TITLE
Resolve Publishing Option Inheritance Issue in Winds Subprojects

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -526,6 +526,7 @@ public final class dev/teogor/winds/api/Person$DeveloperContributor : dev/teogor
 }
 
 public abstract interface class dev/teogor/winds/api/PublishingOptions {
+	public abstract fun copy (Ldev/teogor/winds/api/PublishingOptions;)Ldev/teogor/winds/api/PublishingOptions;
 	public abstract fun getCascadePublish ()Z
 	public abstract fun getEnablePublicationSigning ()Z
 	public abstract fun getOptInForVanniktechPlugin ()Z

--- a/api/src/main/kotlin/dev/teogor/winds/api/PublishingOptions.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/PublishingOptions.kt
@@ -24,4 +24,6 @@ interface PublishingOptions {
   var optInForVanniktechPlugin: Boolean
   var cascadePublish: Boolean
   var sonatypeHost: SonatypeHost
+
+  fun copy(from: PublishingOptions): PublishingOptions
 }

--- a/api/src/main/kotlin/dev/teogor/winds/ktx/WindsExtensions.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/ktx/WindsExtensions.kt
@@ -51,6 +51,9 @@ fun Project.inheritFromParentWinds(winds: Winds) {
     winds.moduleMetadata = winds.moduleMetadata.copy(
       fromObj = parentWinds.moduleMetadata,
     )
+    winds.publishingOptions = winds.publishingOptions.copy(
+      from = parentWinds.publishingOptions,
+    )
 
     val dependencySpec = parentWinds.moduleMetadata.artifactDescriptor
     winds.allSpecs.addAll(parentWinds.allSpecs.toList().asReversed())

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -154,14 +154,10 @@ winds {
     }
   }
 
-  // not required. just an example
-  // configureProjects(
-  //   includeRoot = true,
-  // ) { winds ->
-  //   configureMavenPublishing(winds) {
-  //
-  //   }
-  // }
+  configureProjects(
+    includeRoot = true,
+  ) { winds ->
+  }
 }
 
 // todo context winds not windsOptions

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -184,6 +184,7 @@ public class dev/teogor/winds/api/impl/ModuleMetadataImpl : dev/teogor/winds/api
 
 public class dev/teogor/winds/api/impl/PublishingOptionsImpl : dev/teogor/winds/api/PublishingOptions {
 	public fun <init> ()V
+	public fun copy (Ldev/teogor/winds/api/PublishingOptions;)Ldev/teogor/winds/api/PublishingOptions;
 	public fun getCascadePublish ()Z
 	public fun getEnablePublicationSigning ()Z
 	public fun getOptInForVanniktechPlugin ()Z

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/PublishingOptionsImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/PublishingOptionsImpl.kt
@@ -25,4 +25,12 @@ open class PublishingOptionsImpl : PublishingOptions {
   override var optInForVanniktechPlugin: Boolean = true
   override var cascadePublish: Boolean = true
   override var sonatypeHost: SonatypeHost = SonatypeHost.DEFAULT
+
+  override fun copy(from: PublishingOptions): PublishingOptions {
+    enablePublicationSigning = from.enablePublicationSigning
+    optInForVanniktechPlugin = from.optInForVanniktechPlugin
+    cascadePublish = from.cascadePublish
+    sonatypeHost = from.sonatypeHost
+    return this
+  }
 }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
@@ -124,7 +124,6 @@ class WindsPlugin : BaseWindsPlugin {
         configureMavenPublishing(this)
         if (!hasVanniktechMavenPlugin()) {
           publishingOptions.publish = false
-          println("$path can not be published. ${publishingOptions.publish}")
         }
 
         fun getPublishTask(project: Project): Task {


### PR DESCRIPTION
## Resolve Publishing Option Inheritance Issue in Winds Subprojects

This pull request addresses a bug that prevented `PublishingOptions` configured within the `winds` extension block from being correctly propagated to child subprojects. This resulted in child projects not inheriting the intended publishing settings.

**Changes:**

- **Improved Inheritance:** Modifies the implementation to ensure that `PublishingOptions` are correctly inherited by child subprojects within the `winds` extension block.
- **Enhanced Consistency:** Guarantees consistent publishing behavior across all projects using the Winds plugin.

**Benefits:**

- **Streamlined Configuration:** Eliminates the need to manually duplicate publishing options in each subproject.
- **Simplified Maintenance:** Centralizes publishing configuration within the parent project for better maintainability.


Closes #60 