### PR TITLE
Fixing Illegal `groupId` Modification in Gradle Plugin Subproject

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -1604,6 +1604,7 @@ public final class dev/teogor/winds/ktx/PersonExtensionsKt {
 }
 
 public final class dev/teogor/winds/ktx/ProjectExtensionsKt {
+	public static final fun hasPublishGradlePlugin (Lorg/gradle/api/Project;)Z
 	public static final fun isRootProject (Lorg/gradle/api/Project;)Z
 }
 

--- a/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
@@ -20,7 +20,9 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import dev.teogor.winds.api.Winds
 import dev.teogor.winds.common.ktx.hasVanniktechMavenPlugin
 import dev.teogor.winds.common.ktx.toPom
+import dev.teogor.winds.ktx.hasPublishGradlePlugin
 import org.gradle.api.Project
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 
 fun Project.configureMavenPublishing(
   winds: Winds,
@@ -38,12 +40,21 @@ fun Project.configureMavenPublishing(
 
       @Suppress("UnstableApiUsage")
       pom { mavenPom ->
-        metadata.artifactDescriptor?.let { dependencySpec ->
-          coordinates(
-            groupId = dependencySpec.group,
-            artifactId = dependencySpec.artifactId,
-            version = dependencySpec.version.toString(),
-          )
+        if (hasPublishGradlePlugin()) {
+          extensions.findByType(GradlePluginDevelopmentExtension::class.java)?.let {
+            with(it) {
+              website.set(metadata.websiteUrl)
+              vcsUrl.set(metadata.scm?.repositoryUrl)
+            }
+          }
+        } else {
+          metadata.artifactDescriptor?.let { dependencySpec ->
+            coordinates(
+              groupId = dependencySpec.group,
+              artifactId = dependencySpec.artifactId,
+              version = dependencySpec.version.toString(),
+            )
+          }
         }
 
         metadata toPom mavenPom

--- a/examples/plugin/build.gradle.kts
+++ b/examples/plugin/build.gradle.kts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  `kotlin-dsl`
+  alias(libs.plugins.gradle.publish)
+  alias(libs.plugins.build.config)
+  alias(libs.plugins.jetbrains.kotlin.serialization)
+  id("dev.teogor.winds")
+}
+
+@Suppress("UnstableApiUsage")
+gradlePlugin {
+  plugins {
+    register("windsPlugin") {
+      id = "dev.teogor.demo"
+      implementationClass = "dev.teogor.demo.DemoPlugin"
+      displayName = "Winds Demo Plugin"
+      description = "Automates project workflows, Maven publishing, and documentation generation."
+      tags = listOf("workflow", "Maven", "documentation", "automation", "project-management", "publishing", "reporting")
+    }
+  }
+}
+
+buildConfig {
+  packageName(group.toString())
+
+  buildConfigField("String", "NAME", "\"${group}\"")
+  buildConfigField("String", "VERSION", "\"${version}\"")
+}

--- a/examples/plugin/src/main/kotlin/dev/teogor/demo/DemoPlugin.kt
+++ b/examples/plugin/src/main/kotlin/dev/teogor/demo/DemoPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 teogor (Teodor Grigor)
+ * Copyright 2023 teogor (Teodor Grigor)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package dev.teogor.winds.ktx
+package dev.teogor.demo
 
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-fun Project.isRootProject(): Boolean {
-  return project.projectDir == rootProject.rootDir
-}
-
-fun Project.hasPublishGradlePlugin(): Boolean {
-  return plugins.hasPlugin("com.gradle.plugin-publish")
+class DemoPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+  }
 }

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -26,6 +26,7 @@ include(":bom")
 include(":demo")
 include(":demo-1")
 include(":demo-2")
+include(":plugin")
 
 include(":kmp:android")
 

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
@@ -71,6 +71,10 @@ class WindsPlugin : BaseWindsPlugin {
           inheritFromParentWinds(this)
           configureMavenPublish(this)
 
+          val depSpec = this@withWinds.moduleMetadata.artifactDescriptor
+          project.group = depSpec?.group ?: "unspecified"
+          project.version = depSpec?.version?.toString() ?: "unspecified"
+
           if (isRootProject()) {
             val collectWindsExtensions = configureCollectWindsExtensionsTask()
             tasks.register<DocsGeneratorTask>("docsGeneratorTask") {


### PR DESCRIPTION
## Address Illegal `groupId` Modification in Gradle Plugin Subproject

**Changes:**

- **Safely Update `groupId`:** The code has been modified to avoid directly modifying the `groupId` within the `mavenPom` block. This ensures adherence to recommended Gradle APIs and avoids potential unintended consequences.


Closes #62 