### PR TITLE
Refine Random Library Selection with Publish Filter

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/docs/utils/BomNotes.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/docs/utils/BomNotes.kt
@@ -128,9 +128,13 @@ fun bomMd(
   val ticketSystem = bomModule.ticketSystem
   val libraryByVersion = modules.filterNot {
     it.isBomLibrary()
+  }.filter {
+    it.publish
   }.random(Random(0))
   val library = modules.filterNot {
     it.isBomLibrary()
+  }.filter {
+    it.publish
   }.random(Random(1))
 
   file.replaceContentsWithinRegion(


### PR DESCRIPTION
## Prioritize Publishing Libraries for Random Selection

This pull request modifies the code for selecting random libraries from a list.

**Current Behavior:**

The code previously selected random libraries from the list by filtering out BOM (Bill of Materials) libraries but selecting any remaining library regardless of its publishing status.

**Change:**

- The code now filters out BOM libraries **and** libraries that don't have the `publish` flag set to `true`.
- This ensures that only libraries intended for publishing are considered when selecting random library candidates.
- Two separate `Random` instances with distinct seeds (0 and 1) are still used to maintain unique random selections for each variable (`libraryByVersion` and `library`).

**Benefits:**

- Ensures random selection prioritizes libraries actively intended for publishing.
- Avoids the selection of non-publishing libraries that might not be relevant for the use case.