### PR TITLE
Enable vanniktech-maven-publish Integration with SonatypeHost

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -475,12 +475,12 @@ public abstract interface class dev/teogor/winds/api/Publishing {
 	public abstract fun getEnablePublicationSigning ()Z
 	public abstract fun getEnabled ()Z
 	public abstract fun getOptInForVanniktechPlugin ()Z
-	public abstract fun getSonatypeHost ()Lcom/vanniktech/maven/publish/SonatypeHost;
+	public abstract fun getSonatypeHost ()Ldev/teogor/winds/api/SonatypeHost;
 	public abstract fun setCascade (Z)V
 	public abstract fun setEnablePublicationSigning (Z)V
 	public abstract fun setEnabled (Z)V
 	public abstract fun setOptInForVanniktechPlugin (Z)V
-	public abstract fun setSonatypeHost (Lcom/vanniktech/maven/publish/SonatypeHost;)V
+	public abstract fun setSonatypeHost (Ldev/teogor/winds/api/SonatypeHost;)V
 }
 
 public abstract interface class dev/teogor/winds/api/PublishingOptions {
@@ -661,6 +661,17 @@ public final class dev/teogor/winds/api/Scm$Local : dev/teogor/winds/api/Scm {
 	public final fun setPath (Ljava/lang/String;)V
 	public fun setRepository (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/teogor/winds/api/SonatypeHost : java/lang/Enum {
+	public static final field CENTRAL_PORTAL Ldev/teogor/winds/api/SonatypeHost;
+	public static final field DEFAULT Ldev/teogor/winds/api/SonatypeHost;
+	public static final field S01 Ldev/teogor/winds/api/SonatypeHost;
+	public final fun getRootUrl ()Ljava/lang/String;
+	public final fun isCentralPortal ()Z
+	public final fun toVanniktechSonatypeHost ()Lcom/vanniktech/maven/publish/SonatypeHost;
+	public static fun valueOf (Ljava/lang/String;)Ldev/teogor/winds/api/SonatypeHost;
+	public static fun values ()[Ldev/teogor/winds/api/SonatypeHost;
 }
 
 public final class dev/teogor/winds/api/SpotlessOptions {

--- a/api/src/main/kotlin/dev/teogor/winds/api/Publishing.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/Publishing.kt
@@ -16,8 +16,6 @@
 
 package dev.teogor.winds.api
 
-import com.vanniktech.maven.publish.SonatypeHost
-
 interface Publishing {
   var enabled: Boolean
   var cascade: Boolean

--- a/api/src/main/kotlin/dev/teogor/winds/api/SonatypeHost.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/SonatypeHost.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.api
+
+/**
+ * Describes the various hosts for Sonatype OSSRH. Depending on when a user signed up with Sonatype
+ * they have to use different hosts.
+ *
+ * See [New Users on S01.oss.sonatype.org](https://central.sonatype.org/articles/2021/Feb/23/new-users-on-s01osssonatypeorg/) for more information.
+ */
+enum class SonatypeHost(
+  /** The root URL for the Sonatype host. */
+  val rootUrl: String,
+  /** Whether this host is the Sonatype Central Portal. */
+  val isCentralPortal: Boolean,
+) {
+  /**
+   * The default host for users who signed up before February 2021.
+   *
+   * Root URL: https://oss.sonatype.org
+   * Central Portal: False
+   */
+  DEFAULT("https://oss.sonatype.org", false),
+
+  /**
+   * The host for new users who signed up after February 2021.
+   *
+   * Root URL: https://s01.oss.sonatype.org
+   * Central Portal: False
+   */
+  S01("https://s01.oss.sonatype.org", false),
+
+  /**
+   * The Sonatype Central Portal for users with specific access.
+   *
+   * Root URL: https://central.sonatype.com
+   * Central Portal: True
+   */
+  CENTRAL_PORTAL("https://central.sonatype.com", true),
+  ;
+
+  /**
+   * Converts this SonatypeHost enum instance to a [com.vanniktech.maven.publish.SonatypeHost]
+   * instance.
+   *
+   * @return A new [com.vanniktech.maven.publish.SonatypeHost] instance.
+   */
+  fun toVanniktechSonatypeHost(): com.vanniktech.maven.publish.SonatypeHost {
+    return when (this) {
+      DEFAULT -> com.vanniktech.maven.publish.SonatypeHost.DEFAULT
+      S01 -> com.vanniktech.maven.publish.SonatypeHost.S01
+      CENTRAL_PORTAL -> com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL
+    }
+  }
+}

--- a/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
@@ -29,12 +29,12 @@ fun Project.configureMavenPublishing(
   configureAction: MavenPublishBaseExtension.() -> Unit = {},
 ) {
   val metadata = winds.moduleMetadata
-  val publishingOptions = winds.publishingOptions
-  if (publishingOptions.publish && hasVanniktechMavenPlugin()) {
+  val publishing = winds.publishing
+  if (publishing.enabled && hasVanniktechMavenPlugin()) {
     val mavenPublishing = extensions.getByType(MavenPublishBaseExtension::class.java)
     mavenPublishing.apply {
-      publishToMavenCentral(publishingOptions.sonatypeHost)
-      if (publishingOptions.enablePublicationSigning) {
+      publishToMavenCentral(publishing.sonatypeHost.toVanniktechSonatypeHost())
+      if (publishing.enablePublicationSigning) {
         signAllPublications()
       }
 

--- a/demo/ceres/build.gradle.kts
+++ b/demo/ceres/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.SonatypeHost
+import dev.teogor.winds.api.SonatypeHost
 import dev.teogor.winds.api.ArtifactIdFormat
 import dev.teogor.winds.api.License
 import dev.teogor.winds.api.Person
@@ -110,7 +110,7 @@ winds {
 
     enablePublicationSigning = true
     optInForVanniktechPlugin = true
-    sonatypeHost = SonatypeHost.S01
+    sonatypeHost = com.vanniktech.maven.publish.SonatypeHost.S01
   }
 
   documentationBuilder {

--- a/demo/querent/build.gradle.kts
+++ b/demo/querent/build.gradle.kts
@@ -1,5 +1,5 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.winds.api.ArtifactIdFormat
+import dev.teogor.winds.api.SonatypeHost
 import dev.teogor.winds.api.License
 import dev.teogor.winds.api.NameFormat
 import dev.teogor.winds.api.Person

--- a/demo/sudoklify/build.gradle.kts
+++ b/demo/sudoklify/build.gradle.kts
@@ -1,5 +1,5 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.winds.api.ArtifactIdFormat
+import dev.teogor.winds.api.SonatypeHost
 import dev.teogor.winds.api.License
 import dev.teogor.winds.api.NameFormat
 import dev.teogor.winds.api.Person

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -101,12 +101,12 @@ public class dev/teogor/winds/api/impl/PublishingImpl : dev/teogor/winds/api/Pub
 	public fun getEnablePublicationSigning ()Z
 	public fun getEnabled ()Z
 	public fun getOptInForVanniktechPlugin ()Z
-	public fun getSonatypeHost ()Lcom/vanniktech/maven/publish/SonatypeHost;
+	public fun getSonatypeHost ()Ldev/teogor/winds/api/SonatypeHost;
 	public fun setCascade (Z)V
 	public fun setEnablePublicationSigning (Z)V
 	public fun setEnabled (Z)V
 	public fun setOptInForVanniktechPlugin (Z)V
-	public fun setSonatypeHost (Lcom/vanniktech/maven/publish/SonatypeHost;)V
+	public fun setSonatypeHost (Ldev/teogor/winds/api/SonatypeHost;)V
 }
 
 public class dev/teogor/winds/api/impl/PublishingOptionsImpl : dev/teogor/winds/api/PublishingOptions {

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/PublishingImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/PublishingImpl.kt
@@ -16,8 +16,8 @@
 
 package dev.teogor.winds.api.impl
 
-import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.winds.api.Publishing
+import dev.teogor.winds.api.SonatypeHost
 
 open class PublishingImpl : Publishing {
   override var enabled: Boolean = true

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/WindsImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/WindsImpl.kt
@@ -16,6 +16,7 @@
 
 package dev.teogor.winds.api.impl
 
+import com.vanniktech.maven.publish.SonatypeHost
 import dev.teogor.winds.api.ArtifactDescriptor
 import dev.teogor.winds.api.CodebaseOptions
 import dev.teogor.winds.api.DocsGenerator
@@ -73,7 +74,11 @@ abstract class WindsImpl(
     with(publishingOptions) {
       publishing.enabled = publish
       publishing.cascade = cascadePublish
-      publishing.sonatypeHost = sonatypeHost
+      publishing.sonatypeHost = when (sonatypeHost) {
+        SonatypeHost.CENTRAL_PORTAL -> dev.teogor.winds.api.SonatypeHost.CENTRAL_PORTAL
+        SonatypeHost.S01 -> dev.teogor.winds.api.SonatypeHost.S01
+        else -> dev.teogor.winds.api.SonatypeHost.DEFAULT
+      }
       publishing.optInForVanniktechPlugin = optInForVanniktechPlugin
       publishing.enablePublicationSigning = enablePublicationSigning
     }

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
@@ -62,11 +62,11 @@ class WindsPlugin : BaseWindsPlugin {
         configureMavenPublish(this)
         configureMavenPublishing(this)
         if (!hasVanniktechMavenPlugin()) {
-          publishingOptions.publish = false
+          publishing.enabled = false
         }
 
         configurePublishTask(
-          cascadePublish = publishingOptions.cascadePublish,
+          cascadePublish = publishing.cascade,
         )
 
         val taskName = "windsMd"
@@ -125,7 +125,7 @@ class WindsPlugin : BaseWindsPlugin {
       path = Path.from(project),
       artifact = artifactDescriptor,
       dependencies = artifactDescriptor.artifacts.drop(1),
-      publish = winds.publishingOptions.publish,
+      publish = winds.publishing.enabled,
       completeName = artifactDescriptor.completeName,
       description = winds.moduleMetadata.description,
       documentationBuilder = winds.documentationBuilder,


### PR DESCRIPTION
## SonatypeHost Integration and Conversion Utility

This pull request introduces a new `SonatypeHost` enum and a conversion utility for the Winds Gradle plugin.

**Motivation:**

- The Winds plugin interacts with Sonatype repositories for publishing artifacts.
- This integration facilitates a more flexible approach to specifying Sonatype hosts based on user needs.

**Changes:**

- A new `SonatypeHost` enum has been defined to represent different Sonatype OSSRH hosts (DEFAULT, S01, CENTRAL_PORTAL).
- Each enum value includes the root URL and a flag indicating if it's the Sonatype Central Portal.
- A `toVanniktechSonatypeHost` function is introduced to convert a `SonatypeHost` enum instance to a corresponding `com.vanniktech.maven.publish.SonatypeHost` instance. This enables seamless integration with the vanniktech-maven-publish library.

**Benefits:**

- Provides a structured way to manage Sonatype host configurations.
- Simplifies integration with vanniktech-maven-publish for publishing tasks.

**Usage:**

- Utilize the `SonatypeHost` enum to specify the desired Sonatype host within your Winds Gradle configuration.
- Leverage the `toVanniktechSonatypeHost` function when interacting with vanniktech-maven-publish for publishing purposes.

**Additional Notes:**

- This integration assumes you're using the vanniktech-maven-publish library for publishing tasks.

By introducing the `SonatypeHost` enum and conversion utility, we enhance flexibility and streamline Sonatype host management within the Winds Gradle plugin.
