### PR TITLE
Use Dedicated Features Interface instead of WindsFeatures

### DIFF
--- a/api/api/api.api
+++ b/api/api/api.api
@@ -205,6 +205,15 @@ public final class dev/teogor/winds/api/DokkaOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class dev/teogor/winds/api/Features {
+	public abstract fun getDocsGenerator ()Z
+	public abstract fun getMavenPublishing ()Z
+	public abstract fun getWorkflowSynthesizer ()Z
+	public abstract fun setDocsGenerator (Z)V
+	public abstract fun setMavenPublishing (Z)V
+	public abstract fun setWorkflowSynthesizer (Z)V
+}
+
 public abstract interface class dev/teogor/winds/api/License {
 	public abstract fun getComments ()Ljava/lang/String;
 	public abstract fun getDistribution ()Ldev/teogor/winds/api/Distribution;
@@ -817,10 +826,12 @@ public abstract interface class dev/teogor/winds/api/Winds {
 	public static synthetic fun configureProjects$default (Ldev/teogor/winds/api/Winds;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public abstract fun docsGenerator (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun documentationBuilder (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun features (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getAllSpecs ()Ljava/util/List;
 	public abstract fun getCodebaseOptions ()Ldev/teogor/winds/api/CodebaseOptions;
 	public abstract fun getDocsGenerator ()Ldev/teogor/winds/api/DocsGenerator;
 	public abstract fun getDocumentationBuilder ()Ldev/teogor/winds/api/DocumentationBuilder;
+	public abstract fun getFeatures ()Ldev/teogor/winds/api/Features;
 	public abstract fun getModuleMetadata ()Ldev/teogor/winds/api/ModuleMetadata;
 	public abstract fun getPublishing ()Ldev/teogor/winds/api/Publishing;
 	public abstract fun getPublishingOptions ()Ldev/teogor/winds/api/PublishingOptions;
@@ -833,6 +844,7 @@ public abstract interface class dev/teogor/winds/api/Winds {
 	public abstract fun setCodebaseOptions (Ldev/teogor/winds/api/CodebaseOptions;)V
 	public abstract fun setDocsGenerator (Ldev/teogor/winds/api/DocsGenerator;)V
 	public abstract fun setDocumentationBuilder (Ldev/teogor/winds/api/DocumentationBuilder;)V
+	public abstract fun setFeatures (Ldev/teogor/winds/api/Features;)V
 	public abstract fun setModuleMetadata (Ldev/teogor/winds/api/ModuleMetadata;)V
 	public abstract fun setPublishing (Ldev/teogor/winds/api/Publishing;)V
 	public abstract fun setPublishingOptions (Ldev/teogor/winds/api/PublishingOptions;)V

--- a/api/src/main/kotlin/dev/teogor/winds/api/Features.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/Features.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 teogor (Teodor Grigor)
+ * Copyright 2024 teogor (Teodor Grigor)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,7 @@ package dev.teogor.winds.api
  * This interface allows enabling or disabling specific features
  * that are relevant for projects leveraging the `winds` functionality.
  */
-@Deprecated(
-  message = "Use Features interface instead. This interface is deprecated and will be removed in future versions.",
-  replaceWith = ReplaceWith(expression = "Features"),
-)
-interface WindsFeatures {
+interface Features {
 
   /**
    * Enables or disables Maven publishing for the project.

--- a/api/src/main/kotlin/dev/teogor/winds/api/Winds.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/api/Winds.kt
@@ -22,8 +22,22 @@ import org.gradle.api.Project
 interface Winds {
   val allSpecs: MutableList<ArtifactDescriptor>
 
+  var features: Features
+
+  fun features(action: Features.() -> Unit)
+
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    message = "Use features instead.",
+    replaceWith = ReplaceWith(expression = "features"),
+  )
   var windsFeatures: WindsFeatures
 
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    message = "Use features(action) instead.",
+    replaceWith = ReplaceWith(expression = "features(action)"),
+  )
   fun windsFeatures(action: WindsFeatures.() -> Unit)
 
   var moduleMetadata: ModuleMetadata
@@ -72,11 +86,11 @@ interface Winds {
   infix fun isEnabled(feature: WindsFeature): Boolean {
     return when (feature) {
       WindsFeature.API_VALIDATOR -> false
-      WindsFeature.DOCS_GENERATOR -> windsFeatures.docsGenerator
+      WindsFeature.DOCS_GENERATOR -> features.docsGenerator
       WindsFeature.DOKKA -> false
-      WindsFeature.MAVEN_PUBLISH -> windsFeatures.mavenPublishing
+      WindsFeature.MAVEN_PUBLISH -> features.mavenPublishing
       WindsFeature.SPOTLESS -> false
-      WindsFeature.WORKFLOW_SYNTHESIZER -> windsFeatures.workflowSynthesizer
+      WindsFeature.WORKFLOW_SYNTHESIZER -> features.workflowSynthesizer
     }
   }
 }

--- a/api/src/main/kotlin/dev/teogor/winds/ktx/WindsExtensions.kt
+++ b/api/src/main/kotlin/dev/teogor/winds/ktx/WindsExtensions.kt
@@ -19,6 +19,7 @@ package dev.teogor.winds.ktx
 import dev.teogor.winds.api.CodebaseOptions
 import dev.teogor.winds.api.DocsGenerator
 import dev.teogor.winds.api.DocumentationBuilder
+import dev.teogor.winds.api.Features
 import dev.teogor.winds.api.ModuleMetadata
 import dev.teogor.winds.api.Publishing
 import dev.teogor.winds.api.PublishingOptions
@@ -75,6 +76,7 @@ fun Project.inheritFromParentWinds(winds: Winds) {
 
 inline operator fun <reified T> Winds.getValue(thisRef: Nothing?, property: KProperty<*>): T {
   return when (T::class) {
+    Features::class -> features as T
     WindsFeatures::class -> windsFeatures as T
     DocumentationBuilder::class -> documentationBuilder as T
     ModuleMetadata::class -> moduleMetadata as T

--- a/demo/ceres/build.gradle.kts
+++ b/demo/ceres/build.gradle.kts
@@ -46,6 +46,12 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 winds {
+  features {
+    mavenPublishing = true
+    docsGenerator = true
+    workflowSynthesizer = true
+  }
+
   windsFeatures {
     mavenPublishing = true
     docsGenerator = true

--- a/demo/querent/build.gradle.kts
+++ b/demo/querent/build.gradle.kts
@@ -48,7 +48,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 winds {
-  windsFeatures {
+  features {
     mavenPublishing = true
     docsGenerator = true
     workflowSynthesizer = true

--- a/demo/sudoklify/build.gradle.kts
+++ b/demo/sudoklify/build.gradle.kts
@@ -48,7 +48,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 winds {
-  windsFeatures {
+  features {
     mavenPublishing = true
     docsGenerator = true
     workflowSynthesizer = true

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -60,6 +60,26 @@ public final class dev/teogor/winds/api/impl/DocumentationBuilderImpl : dev/teog
 	public fun setOptional (Z)V
 }
 
+public final class dev/teogor/winds/api/impl/FeaturesImpl : dev/teogor/winds/api/Features {
+	public fun <init> ()V
+	public fun <init> (ZZZ)V
+	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (ZZZ)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/impl/FeaturesImpl;ZZZILjava/lang/Object;)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDocsGenerator ()Z
+	public fun getMavenPublishing ()Z
+	public fun getWorkflowSynthesizer ()Z
+	public fun hashCode ()I
+	public fun setDocsGenerator (Z)V
+	public fun setMavenPublishing (Z)V
+	public fun setWorkflowSynthesizer (Z)V
+	public fun toString ()Ljava/lang/String;
+}
+
 public class dev/teogor/winds/api/impl/ModuleMetadataImpl : dev/teogor/winds/api/ModuleMetadata {
 	public fun <init> ()V
 	public fun artifactDescriptor (Lkotlin/jvm/functions/Function1;)V
@@ -140,10 +160,12 @@ public abstract class dev/teogor/winds/api/impl/WindsImpl : dev/teogor/winds/api
 	public fun configureProjects (ZLkotlin/jvm/functions/Function2;)V
 	public fun docsGenerator (Lkotlin/jvm/functions/Function1;)V
 	public fun documentationBuilder (Lkotlin/jvm/functions/Function1;)V
+	public fun features (Lkotlin/jvm/functions/Function1;)V
 	public fun getAllSpecs ()Ljava/util/List;
 	public fun getCodebaseOptions ()Ldev/teogor/winds/api/CodebaseOptions;
 	public fun getDocsGenerator ()Ldev/teogor/winds/api/DocsGenerator;
 	public fun getDocumentationBuilder ()Ldev/teogor/winds/api/DocumentationBuilder;
+	public fun getFeatures ()Ldev/teogor/winds/api/Features;
 	public fun getModuleMetadata ()Ldev/teogor/winds/api/ModuleMetadata;
 	public fun getPublishing ()Ldev/teogor/winds/api/Publishing;
 	public fun getPublishingOptions ()Ldev/teogor/winds/api/PublishingOptions;
@@ -155,6 +177,7 @@ public abstract class dev/teogor/winds/api/impl/WindsImpl : dev/teogor/winds/api
 	public fun setCodebaseOptions (Ldev/teogor/winds/api/CodebaseOptions;)V
 	public fun setDocsGenerator (Ldev/teogor/winds/api/DocsGenerator;)V
 	public fun setDocumentationBuilder (Ldev/teogor/winds/api/DocumentationBuilder;)V
+	public fun setFeatures (Ldev/teogor/winds/api/Features;)V
 	public fun setModuleMetadata (Ldev/teogor/winds/api/ModuleMetadata;)V
 	public fun setPublishing (Ldev/teogor/winds/api/Publishing;)V
 	public fun setPublishingOptions (Ldev/teogor/winds/api/PublishingOptions;)V

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/FeaturesImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/FeaturesImpl.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.api.impl
+
+import dev.teogor.winds.api.Features
+
+data class FeaturesImpl(
+  override var mavenPublishing: Boolean = false,
+  override var docsGenerator: Boolean = false,
+  override var workflowSynthesizer: Boolean = false,
+) : Features

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/WindsImpl.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/WindsImpl.kt
@@ -21,6 +21,7 @@ import dev.teogor.winds.api.ArtifactDescriptor
 import dev.teogor.winds.api.CodebaseOptions
 import dev.teogor.winds.api.DocsGenerator
 import dev.teogor.winds.api.DocumentationBuilder
+import dev.teogor.winds.api.Features
 import dev.teogor.winds.api.ModuleMetadata
 import dev.teogor.winds.api.Publishing
 import dev.teogor.winds.api.PublishingOptions
@@ -39,10 +40,31 @@ abstract class WindsImpl(
 ) : Winds {
   override val allSpecs: MutableList<ArtifactDescriptor> = mutableListOf()
 
+  override var features: Features = FeaturesImpl()
+
+  override fun features(action: Features.() -> Unit) {
+    features = features.apply(action)
+  }
+
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    message = "Use features instead.",
+    replaceWith = ReplaceWith("features"),
+  )
   override var windsFeatures: WindsFeatures = WindsFeaturesImpl()
 
+  @Suppress("DEPRECATION")
+  @Deprecated(
+    message = "Use features(action) instead.",
+    replaceWith = ReplaceWith("features(action)"),
+  )
   override fun windsFeatures(action: WindsFeatures.() -> Unit) {
     windsFeatures = windsFeatures.apply(action)
+    with(windsFeatures) {
+      features.mavenPublishing = mavenPublishing
+      features.docsGenerator = docsGenerator
+      features.workflowSynthesizer = workflowSynthesizer
+    }
   }
 
   override var moduleMetadata: ModuleMetadata = ModuleMetadataImpl()


### PR DESCRIPTION
## Deprecate windsFeatures in Favor of Dedicated Features Interface

This pull request introduces a new `Features` interface and deprecates the existing `WindsFeatures` interface within the Winds Gradle plugin configuration.

**Motivation:**

- The `WindsFeatures` interface served as a container for project feature configuration.
- Replacing it with a dedicated `Features` interface improves code organization and promotes a more structured approach to feature management.

**Changes:**

- A new `Features` interface has been defined, inheriting all properties from `WindsFeatures`.
- `WindsFeatures` is now marked as deprecated with appropriate annotations to guide users towards the new interface.
- Code using `windsFeatures` properties has been updated to utilize the corresponding properties within the `features` interface.

**Benefits:**

- Enhances code clarity and maintainability with a dedicated interface for feature configuration.
- Provides a clear migration path for users by deprecating the old interface gracefully.

**Impact and Usage:**

- Any existing code that relies on `windsFeatures` properties will need to be updated to use the corresponding properties within the new `Features` interface.
