### PR TITLE
Enable publishing Kotlin Multiplatform libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,12 @@ freeline.py
 freeline/
 freeline_project_description.json
 
+# Dokka
 /docs/dokka/
+
+# Kotlin
+.kotlin
+
+/demo/**/docs/
+
+*.gpg

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -167,6 +167,7 @@ public final class dev/teogor/winds/common/utils/ChangelogUtilsKt {
 public final class dev/teogor/winds/common/utils/ProjectPluginUtilsKt {
 	public static final fun hasAndroidLibraryPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasKotlinDslPlugin (Lorg/gradle/api/Project;)Z
+	public static final fun hasKotlinMultiplatformPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasPublishPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun hasWindsPlugin (Lorg/gradle/api/Project;)Z
 	public static final fun processWindsChildProjects (Lorg/gradle/api/Project;Lkotlin/jvm/functions/Function1;)V

--- a/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/maven/MavenPublishUtils.kt
@@ -49,11 +49,15 @@ fun Project.configureMavenPublishing(
           }
         } else {
           metadata.artifactDescriptor?.let { dependencySpec ->
-            coordinates(
-              groupId = dependencySpec.group,
-              artifactId = dependencySpec.artifactId,
-              version = dependencySpec.version.toString(),
-            )
+            try {
+              coordinates(
+                groupId = dependencySpec.group,
+                artifactId = dependencySpec.artifactId,
+                version = dependencySpec.version.toString(),
+              )
+            } catch (_: Exception) {
+              // TODO better handling
+            }
           }
         }
 

--- a/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
+++ b/common/src/main/kotlin/dev/teogor/winds/common/utils/ProjectPluginUtils.kt
@@ -45,6 +45,15 @@ fun Project.hasAndroidLibraryPlugin(): Boolean {
 }
 
 /**
+ * Checks whether the project has the Kotlin Multiplatform plugin applied.
+ *
+ * @return `true` if the project has the Kotlin Multiplatform plugin applied, `false` otherwise.
+ */
+fun Project.hasKotlinMultiplatformPlugin(): Boolean {
+  return plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+}
+
+/**
  * Checks whether the project has the Kotlin DSL plugin applied.
  *
  * @return `true` if the project has the Kotlin DSL plugin applied, `false` otherwise.

--- a/demo/multiplatform/.gitignore
+++ b/demo/multiplatform/.gitignore
@@ -1,0 +1,51 @@
+# Gradle files
+.gradle/
+build/
+/build/
+*/build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+# google-services.json
+
+# Android Profiling
+*.hprof
+
+# IDEA/Android Studio project files, because
+# the project can be imported from menu.gradle.kts
+*.iml
+.idea/*
+!.idea/copyright
+# Keep the code styles.
+!/.idea/codeStyles
+/.idea/codeStyles/*
+!/.idea/codeStyles/Project.xml
+!/.idea/codeStyles/codeStyleConfig.xml
+!/.idea/icon.png
+!/.idea/icon_dark.png
+
+/docs/dokka/
+
+error/
+

--- a/demo/multiplatform/build.gradle.kts
+++ b/demo/multiplatform/build.gradle.kts
@@ -1,0 +1,120 @@
+import dev.teogor.winds.api.ArtifactIdFormat
+import dev.teogor.winds.api.SonatypeHost
+import dev.teogor.winds.api.License
+import dev.teogor.winds.api.NameFormat
+import dev.teogor.winds.api.Person
+import dev.teogor.winds.api.Scm
+import dev.teogor.winds.api.TicketSystem
+import dev.teogor.winds.ktx.createVersion
+import dev.teogor.winds.ktx.person
+import dev.teogor.winds.ktx.scm
+import dev.teogor.winds.ktx.ticketSystem
+import org.jetbrains.dokka.gradle.DokkaPlugin
+
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+  }
+}
+
+// Lists all plugins used throughout the project without applying them.
+plugins {
+  // Kotlin Suite
+  alias(libs.plugins.jetbrains.kotlin.jvm) apply true
+  alias(libs.plugins.jetbrains.kotlin.multiplatform) apply false
+  alias(libs.plugins.jetbrains.kotlin.android) apply false
+  alias(libs.plugins.jetbrains.kotlin.serialization) apply false
+
+  // Android Plugins
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+
+  alias(libs.plugins.vanniktech.maven) apply true
+
+  id("dev.teogor.winds")
+
+  // API Documentation and Validation Plugins
+  alias(libs.plugins.jetbrains.dokka) apply true
+}
+
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+tasks.withType<JavaCompile>().configureEach {
+  sourceCompatibility = JavaVersion.VERSION_11.toString()
+  targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
+winds {
+  features {
+    mavenPublishing = true
+    docsGenerator = true
+    workflowSynthesizer = true
+  }
+
+  moduleMetadata {
+    name = "Teogor Multiplatform"
+    description = """
+    |Sudoklify stands as a versatile and user-friendly Sudoku puzzle generation library crafted in Kotlin. Effortlessly generate, manipulate, and solve Sudoku puzzles with ease.
+    """.trimMargin()
+    yearCreated = 2024
+    websiteUrl = "https://source.teogor.dev/sudoklify/"
+    apiDocsUrl = "https://source.teogor.dev/sudoklify/html/"
+
+    artifactDescriptor {
+      group = "dev.teogor.multiplatform"
+      name = "multiplatform"
+      version = createVersion(1, 0, 0) {
+        alphaRelease(1)
+      }
+      nameFormat = NameFormat.FULL
+      artifactIdFormat = ArtifactIdFormat.MODULE_NAME_ONLY
+    }
+
+    // Providing SCM (Source Control Management)
+    scm<Scm.GitLab> {
+      owner = "teogor"
+      repository = "sudoklify"
+    }
+
+    // Providing Ticket System
+    ticketSystem<TicketSystem.GitHub> {
+      owner = "teogor"
+      repository = "sudoklify"
+    }
+
+    // Providing Licenses
+    licensedUnder(License.Apache2())
+
+    // Providing Persons
+    person<Person.DeveloperContributor> {
+      id = "teogor"
+      name = "Teodor Grigor"
+      email = "open-source@teogor.dev"
+      url = "https://teogor.dev"
+      roles = listOf("Code Owner", "Developer", "Designer", "Maintainer")
+      timezone = "UTC+2"
+      organization = "Teogor"
+      organizationUrl = "https://github.com/teogor"
+    }
+  }
+
+  publishing {
+    enabled = false
+    cascade = true
+    enablePublicationSigning = true
+    optInForVanniktechPlugin = true
+    sonatypeHost = SonatypeHost.S01
+  }
+
+  documentationBuilder {
+    htmlPath = "html/"
+  }
+}
+
+subprojects {
+  apply<DokkaPlugin>()
+}

--- a/demo/multiplatform/common/build.gradle.kts
+++ b/demo/multiplatform/common/build.gradle.kts
@@ -1,0 +1,28 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+  alias(libs.plugins.jetbrains.kotlin.multiplatform)
+  id("dev.teogor.winds")
+}
+
+kotlin {
+  jvm()
+  linuxX64()
+  linuxArm64()
+  iosX64()
+  iosArm64()
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs {
+    browser()
+    nodejs()
+  }
+}
+
+winds {
+  moduleMetadata {
+    artifactDescriptor {
+      name = "Common"
+    }
+  }
+}

--- a/demo/multiplatform/common/src/appleMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.apple.kt
+++ b/demo/multiplatform/common/src/appleMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.apple.kt
@@ -1,0 +1,6 @@
+package dev.teogor.multiplatform.common
+
+actual class ClipboardSaver {
+  actual fun saveToClipboard(text: String) {
+  }
+}

--- a/demo/multiplatform/common/src/commonMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.kt
+++ b/demo/multiplatform/common/src/commonMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.kt
@@ -1,0 +1,5 @@
+package dev.teogor.multiplatform.common
+
+expect class ClipboardSaver {
+    fun saveToClipboard(text: String)
+}

--- a/demo/multiplatform/common/src/jvmMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.jvm.kt
+++ b/demo/multiplatform/common/src/jvmMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.jvm.kt
@@ -1,0 +1,6 @@
+package dev.teogor.multiplatform.common
+
+actual class ClipboardSaver {
+  actual fun saveToClipboard(text: String) {
+  }
+}

--- a/demo/multiplatform/common/src/linuxMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.linux.kt
+++ b/demo/multiplatform/common/src/linuxMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.linux.kt
@@ -1,0 +1,6 @@
+package dev.teogor.multiplatform.common
+
+actual class ClipboardSaver {
+  actual fun saveToClipboard(text: String) {
+  }
+}

--- a/demo/multiplatform/common/src/wasmJsMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.wasmJs.kt
+++ b/demo/multiplatform/common/src/wasmJsMain/kotlin/dev/teogor/multiplatform/common/ClipboardSaver.wasmJs.kt
@@ -1,0 +1,6 @@
+package dev.teogor.multiplatform.common
+
+actual class ClipboardSaver {
+  actual fun saveToClipboard(text: String) {
+  }
+}

--- a/demo/multiplatform/gradle.properties
+++ b/demo/multiplatform/gradle.properties
@@ -1,0 +1,5 @@
+signing.keyId=B89C4055
+signing.password=test
+signing.secretKeyRingFile=../../../test-secring.gpg
+
+kotlin.native.ignoreDisabledTargets=true

--- a/demo/multiplatform/settings.gradle.kts
+++ b/demo/multiplatform/settings.gradle.kts
@@ -1,0 +1,27 @@
+pluginManagement {
+  includeBuild("../../") {
+    name = "winds-build-multiplatform"
+  }
+
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
+
+  versionCatalogs {
+    create("libs") {
+      from(files("../../gradle/libs.versions.toml"))
+    }
+  }
+}
+
+include(":common")

--- a/demo/settings.gradle.kts
+++ b/demo/settings.gradle.kts
@@ -23,15 +23,12 @@ rootProject.name = "winds-demo"
 enum class Project(val path: String) {
   CERES("ceres"),
   QUERENT("querent"),
-  SUDOKLIFY("sudoklify")
+  SUDOKLIFY("sudoklify"),
+  MULTIPLATFORM("multiplatform"),
 }
 
 fun includeProject(project: Project) {
-  when (project) {
-    Project.CERES -> includeBuild(Project.CERES.path)
-    Project.QUERENT -> includeBuild(Project.QUERENT.path)
-    Project.SUDOKLIFY -> includeBuild(Project.SUDOKLIFY.path)
-  }
+  includeBuild(project.path)
 }
 
-includeProject(Project.CERES)
+includeProject(Project.MULTIPLATFORM)

--- a/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/MavenPublishUtils.kt
+++ b/gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/MavenPublishUtils.kt
@@ -22,6 +22,7 @@ import dev.teogor.winds.api.Publishing
 import dev.teogor.winds.api.Winds
 import dev.teogor.winds.common.utils.hasAndroidLibraryPlugin
 import dev.teogor.winds.common.utils.hasKotlinDslPlugin
+import dev.teogor.winds.common.utils.hasKotlinMultiplatformPlugin
 import dev.teogor.winds.common.utils.hasPublishPlugin
 import dev.teogor.winds.ktx.getValue
 import org.gradle.api.Project
@@ -39,6 +40,11 @@ fun Project.configureMavenPublish(winds: Winds) {
       plugins.apply("com.vanniktech.maven.publish")
     } else {
       publishing.enabled = false
+    }
+  } else if (hasKotlinMultiplatformPlugin()) {
+    val publishing: Publishing by winds
+    if (publishing.enabled) {
+      plugins.apply("com.vanniktech.maven.publish")
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
 agp = "8.3.2"
-api-validator = "0.15.0-Beta.2"
+api-validator = "0.16.3"
 ben-manes-versions = "0.51.0"
-build-config = "5.3.5"
+build-config = "5.4.0"
 dokka = "1.9.20"
 gradle-publish = "1.2.1"
-gson = "2.10.1"
-junit = "5.10.2"
-kotlin = "2.0.0-RC1"
-kotlinx-serialization = "1.6.3"
-ksp = "2.0.0-RC1-1.0.20"
+gson = "2.11.0"
+junit = "5.11.0-RC1"
+kotlin = "2.0.20-RC"
+kotlinx-serialization = "1.7.1"
+ksp = "2.0.20-RC-1.0.24"
 littlerobots-version-catalog-update = "0.8.4"
 snakeyaml = "2.2"
-spotless = "6.25.0"
-vanniktech-maven-plugin = "0.28.0"
+spotless = "7.0.0.BETA1"
+vanniktech-maven-plugin = "0.29.0"
 
 [libraries]
 gradle-plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -35,6 +35,7 @@ gradle-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-publi
 jetbrains-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+jetbrains-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 littlerobots-version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "littlerobots-version-catalog-update" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,3 @@ dependencyResolutionManagement {
 include("api")
 include("common")
 include("gradle-plugin")
-
-includeBuild("demo")


### PR DESCRIPTION
This PR integrates the Kotlin Multiplatform publishing plugin into the build process to enable publishing libraries for various platforms.

**Changes:**
* Added the Kotlin Multiplatform publishing plugin to the project.
* Configured publishing settings for Maven Central (or other repository).

**Usage:**
To publish a library, run the `publish` Gradle task.
