### PR TITLE
feat(api): expand Features API with quality tool flags

### DIFF
--- a/winds-api/api/winds-api.api
+++ b/winds-api/api/winds-api.api
@@ -206,11 +206,17 @@ public final class dev/teogor/winds/api/DokkaOptions {
 }
 
 public abstract interface class dev/teogor/winds/api/Features {
+	public abstract fun getApiValidator ()Z
 	public abstract fun getDocsGenerator ()Z
+	public abstract fun getDokka ()Z
 	public abstract fun getMavenPublishing ()Z
+	public abstract fun getSpotless ()Z
 	public abstract fun getWorkflowSynthesizer ()Z
+	public abstract fun setApiValidator (Z)V
 	public abstract fun setDocsGenerator (Z)V
+	public abstract fun setDokka (Z)V
 	public abstract fun setMavenPublishing (Z)V
+	public abstract fun setSpotless (Z)V
 	public abstract fun setWorkflowSynthesizer (Z)V
 }
 

--- a/winds-api/src/main/kotlin/dev/teogor/winds/api/Features.kt
+++ b/winds-api/src/main/kotlin/dev/teogor/winds/api/Features.kt
@@ -53,4 +53,34 @@ interface Features {
    * Defaults to `false`.
    */
   var workflowSynthesizer: Boolean
+
+  /**
+   * Enables or disables the API validator for the project.
+   *
+   * Setting this property to `true` enables the API validation,
+   * ensuring that your project's API remains consistent and compatible.
+   *
+   * Defaults to `false`.
+   */
+  var apiValidator: Boolean
+
+  /**
+   * Enables or disables the Dokka documentation generator for the project.
+   *
+   * Setting this property to `true` enables Dokka, which generates
+   * comprehensive API documentation for your project.
+   *
+   * Defaults to `false`.
+   */
+  var dokka: Boolean
+
+  /**
+   * Enables or disables Spotless for the project.
+   *
+   * Setting this property to `true` enables Spotless, which helps
+   * maintain a consistent code style across your project.
+   *
+   * Defaults to `false`.
+   */
+  var spotless: Boolean
 }

--- a/winds-api/src/main/kotlin/dev/teogor/winds/api/Winds.kt
+++ b/winds-api/src/main/kotlin/dev/teogor/winds/api/Winds.kt
@@ -85,11 +85,11 @@ interface Winds {
 
   infix fun isEnabled(feature: WindsFeature): Boolean {
     return when (feature) {
-      WindsFeature.API_VALIDATOR -> false
+      WindsFeature.API_VALIDATOR -> features.apiValidator
       WindsFeature.DOCS_GENERATOR -> features.docsGenerator
-      WindsFeature.DOKKA -> false
+      WindsFeature.DOKKA -> features.dokka
       WindsFeature.MAVEN_PUBLISH -> features.mavenPublishing
-      WindsFeature.SPOTLESS -> false
+      WindsFeature.SPOTLESS -> features.spotless
       WindsFeature.WORKFLOW_SYNTHESIZER -> features.workflowSynthesizer
     }
   }

--- a/winds-gradle-plugin/api/winds-gradle-plugin.api
+++ b/winds-gradle-plugin/api/winds-gradle-plugin.api
@@ -62,20 +62,29 @@ public final class dev/teogor/winds/api/impl/DocumentationBuilderImpl : dev/teog
 
 public final class dev/teogor/winds/api/impl/FeaturesImpl : dev/teogor/winds/api/Features {
 	public fun <init> ()V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZZZ)V
+	public synthetic fun <init> (ZZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
-	public final fun copy (ZZZ)Ldev/teogor/winds/api/impl/FeaturesImpl;
-	public static synthetic fun copy$default (Ldev/teogor/winds/api/impl/FeaturesImpl;ZZZILjava/lang/Object;)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (ZZZZZZ)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/impl/FeaturesImpl;ZZZZZZILjava/lang/Object;)Ldev/teogor/winds/api/impl/FeaturesImpl;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiValidator ()Z
 	public fun getDocsGenerator ()Z
+	public fun getDokka ()Z
 	public fun getMavenPublishing ()Z
+	public fun getSpotless ()Z
 	public fun getWorkflowSynthesizer ()Z
 	public fun hashCode ()I
+	public fun setApiValidator (Z)V
 	public fun setDocsGenerator (Z)V
+	public fun setDokka (Z)V
 	public fun setMavenPublishing (Z)V
+	public fun setSpotless (Z)V
 	public fun setWorkflowSynthesizer (Z)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/FeaturesImpl.kt
+++ b/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/api/impl/FeaturesImpl.kt
@@ -22,4 +22,7 @@ data class FeaturesImpl(
   override var mavenPublishing: Boolean = false,
   override var docsGenerator: Boolean = false,
   override var workflowSynthesizer: Boolean = false,
+  override var apiValidator: Boolean = false,
+  override var dokka: Boolean = false,
+  override var spotless: Boolean = false,
 ) : Features


### PR DESCRIPTION
# Description

This PR expands the core `Features` API in `winds-api` to support new opt-in flags for project quality tools. This is a foundational change that enables integrated configuration for Spotless, Dokka, and API Validation.

## Changes

### [winds-api]
- **Features.kt**: Added `apiValidator`, `dokka`, and `spotless` Boolean properties with comprehensive KDoc documentation.
- **Winds.kt**: Updated `isEnabled(WindsFeature)` logic to resolve the new flags from the `features` block.

### [winds-gradle-plugin]
- **FeaturesImpl.kt**: Updated the data class implementation to include the new properties with default values (`false`).

## Impact
- No breaking changes. Deprecated `windsFeatures` and `publishingOptions` are retained for backward compatibility as requested.
- Enables granular control over quality tool application through the `winds {}` extension.

## Verification
- Verified by running `./gradlew build` and checking for binary compatibility with `./gradlew apiCheck`.