### PR TITLE
feat(spotless): implement integrated Spotless support

### DIFF
--- a/winds-api/api/winds-api.api
+++ b/winds-api/api/winds-api.api
@@ -206,11 +206,17 @@ public final class dev/teogor/winds/api/DokkaOptions {
 }
 
 public abstract interface class dev/teogor/winds/api/Features {
+	public abstract fun getApiValidator ()Z
 	public abstract fun getDocsGenerator ()Z
+	public abstract fun getDokka ()Z
 	public abstract fun getMavenPublishing ()Z
+	public abstract fun getSpotless ()Z
 	public abstract fun getWorkflowSynthesizer ()Z
+	public abstract fun setApiValidator (Z)V
 	public abstract fun setDocsGenerator (Z)V
+	public abstract fun setDokka (Z)V
 	public abstract fun setMavenPublishing (Z)V
+	public abstract fun setSpotless (Z)V
 	public abstract fun setWorkflowSynthesizer (Z)V
 }
 

--- a/winds-gradle-plugin/api/winds-gradle-plugin.api
+++ b/winds-gradle-plugin/api/winds-gradle-plugin.api
@@ -62,20 +62,29 @@ public final class dev/teogor/winds/api/impl/DocumentationBuilderImpl : dev/teog
 
 public final class dev/teogor/winds/api/impl/FeaturesImpl : dev/teogor/winds/api/Features {
 	public fun <init> ()V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZZZ)V
+	public synthetic fun <init> (ZZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
-	public final fun copy (ZZZ)Ldev/teogor/winds/api/impl/FeaturesImpl;
-	public static synthetic fun copy$default (Ldev/teogor/winds/api/impl/FeaturesImpl;ZZZILjava/lang/Object;)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (ZZZZZZ)Ldev/teogor/winds/api/impl/FeaturesImpl;
+	public static synthetic fun copy$default (Ldev/teogor/winds/api/impl/FeaturesImpl;ZZZZZZILjava/lang/Object;)Ldev/teogor/winds/api/impl/FeaturesImpl;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getApiValidator ()Z
 	public fun getDocsGenerator ()Z
+	public fun getDokka ()Z
 	public fun getMavenPublishing ()Z
+	public fun getSpotless ()Z
 	public fun getWorkflowSynthesizer ()Z
 	public fun hashCode ()I
+	public fun setApiValidator (Z)V
 	public fun setDocsGenerator (Z)V
+	public fun setDokka (Z)V
 	public fun setMavenPublishing (Z)V
+	public fun setSpotless (Z)V
 	public fun setWorkflowSynthesizer (Z)V
 	public fun toString ()Ljava/lang/String;
 }
@@ -381,6 +390,10 @@ public abstract class dev/teogor/winds/gradle/tasks/ReleaseNotesTask : org/gradl
 	public final fun setBuildOutputDir (Ljava/io/File;)V
 	public final fun setForceDateUpdate (Z)V
 	public final fun setOutputDir (Ljava/io/File;)V
+}
+
+public final class dev/teogor/winds/gradle/tasks/SpotlessUtilsKt {
+	public static final fun configureSpotless (Lorg/gradle/api/Project;Ldev/teogor/winds/api/Winds;)V
 }
 
 public final class dev/teogor/winds/gradle/utils/ExtensionsKt {

--- a/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
+++ b/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/WindsPlugin.kt
@@ -26,6 +26,7 @@ import dev.teogor.winds.common.ktx.register
 import dev.teogor.winds.common.maven.configureMavenPublishing
 import dev.teogor.winds.gradle.tasks.ReleaseNotesTask
 import dev.teogor.winds.gradle.tasks.configureMavenPublish
+import dev.teogor.winds.gradle.tasks.configureSpotless
 import dev.teogor.winds.ktx.hasPublishGradlePlugin
 import dev.teogor.winds.ktx.inheritFromParentWinds
 import org.gradle.api.Project
@@ -57,6 +58,7 @@ class WindsPlugin : BaseWindsPlugin {
       onWindsAvailable = {
         inheritFromParentWinds(this)
         configureMavenPublish(this)
+        configureSpotless(this)
 
         extractAndSetProjectDetails(
           depSpec = this@withWinds.moduleMetadata.artifactDescriptor,
@@ -68,6 +70,7 @@ class WindsPlugin : BaseWindsPlugin {
       )
 
       configureMavenPublish(this)
+      configureSpotless(this)
       configureMavenPublishing(this)
       if (!hasVanniktechMavenPlugin()) {
         publishing.enabled = false

--- a/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/SpotlessUtils.kt
+++ b/winds-gradle-plugin/src/main/kotlin/dev/teogor/winds/gradle/tasks/SpotlessUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 teogor (Teodor Grigor)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.teogor.winds.gradle.tasks
+
+import dev.teogor.winds.api.Winds
+import org.gradle.api.Project
+
+fun Project.configureSpotless(winds: Winds) {
+  if (winds.features.spotless) {
+    plugins.apply("com.diffplug.spotless")
+  }
+}


### PR DESCRIPTION
# Description

This PR introduces integrated support for [Spotless](https://github.com/diffplug/spotless), allowing users to easily enable code formatting across their project using the `winds` extension.

## Changes

- **SpotlessUtils.kt**: Created a new utility to handle Spotless plugin application.
- **WindsPlugin.kt**: Integrated `configureSpotless` into the plugin lifecycle, ensuring it responds to the `features.spotless` toggle.

## Usage

Enable Spotless in your `build.gradle.kts`:

```kotlin
winds {
    features {
        spotless = true
    }
}
```

## Verification
- Verified plugin application in a sample module.
- Confirmed that the Spotless plugin is only applied when the flag is set to `true`.